### PR TITLE
New Feature to Allow Guest Network IP Address Reservations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # YazDHCP
 
-## v1.0.10
+## v1.2.0
 
-### Updated on 2025-Aug-05
+### Updated on 2025-Sep-20
 
 ## About
 

--- a/YazDHCP.sh
+++ b/YazDHCP.sh
@@ -13,7 +13,7 @@
 ##    Forked from https://github.com/jackyaz/YazDHCP    ##
 ##                                                      ##
 ##########################################################
-# Last Modified: 2025-Aug-05
+# Last Modified: 2025-Sep-19
 #---------------------------------------------------------
 
 #############################################
@@ -29,8 +29,8 @@
 
 ### Start of script variables ###
 readonly SCRIPT_NAME="YazDHCP"
-readonly SCRIPT_VERSION="v1.0.10"
-readonly SCRIPT_VERSTAG="25080521"
+readonly SCRIPT_VERSION="v1.2.0"
+readonly SCRIPT_VERSTAG="25091923"
 SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/AMTM-OSR/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME.d"
@@ -40,6 +40,10 @@ readonly SCRIPT_WEB_DIR="$SCRIPT_WEBPAGE_DIR/$SCRIPT_NAME"
 readonly SHARED_DIR="/jffs/addons/shared-jy"
 readonly SHARED_REPO="https://raw.githubusercontent.com/AMTM-OSR/shared-jy/master"
 readonly SHARED_WEB_DIR="$SCRIPT_WEBPAGE_DIR/shared-jy"
+readonly SHARED_CUSTOM_CONFIG_NAME="custom_settings.txt"
+readonly SHARED_CUSTOM_CONFIG_FILE="/jffs/addons/$SHARED_CUSTOM_CONFIG_NAME"
+readonly SHARED_CUSTOM_CONFIG_BACKUP="${SCRIPT_DIR}/${SHARED_CUSTOM_CONFIG_NAME}.BKUP"
+
 ### End of script variables ###
 
 ### Start of output format variables ###
@@ -66,13 +70,52 @@ readonly fwInstalledBaseVers="$(nvram get firmver | sed 's/\.//g')"
 readonly fwInstalledBuildVers="$(nvram get buildno)"
 readonly fwInstalledBranchVer="${fwInstalledBaseVers}.${fwInstalledBuildVers}"
 readonly scriptVersRegExp="v[0-9]{1,2}([.][0-9]{1,2})([.][0-9]{1,2})"
-readonly branchx_TAG="Branch: $SCRIPT_BRANCH"
-readonly version_TAG="${SCRIPT_VERSION}_${SCRIPT_VERSTAG}"
+readonly branchxStr_TAG="[Branch: $SCRIPT_BRANCH]"
+readonly versionDev_TAG="${SCRIPT_VERSION}_${SCRIPT_VERSTAG}"
+readonly versionMod_TAG="$SCRIPT_VERSION on $ROUTER_MODEL"
 
 # Give higher priority to built-in binaries #
 export PATH="/bin:/usr/bin:/sbin:/usr/sbin:$PATH"
 
 ### End of router environment variables ###
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+readonly mainLAN_IFname="$(nvram get lan_ifname)"
+readonly mainLAN_IPaddr="$(nvram get lan_ipaddr)"
+readonly mainNET_IPmask="$(nvram get lan_netmask)"
+readonly wifiIFnameList="$(nvram get wl_ifnames)"
+
+# For Guest Network Virtual Interfaces #
+readonly guestNetIFaces0RegExp="(wl[0-3][.][1-3]|br[1-9][0-9]?)"
+readonly guestNetIFaces1RegExp="${guestNetIFaces0RegExp}[[:blank:]]* Link encap:"
+readonly guestNetIFaces2RegExp="dev[[:blank:]]* ${guestNetIFaces0RegExp}[[:blank:]]* proto kernel"
+
+# MAC addresses #
+readonly MACaddr_RegEx="([a-fA-F0-9]{2}([:][a-fA-F0-9]{2}){5})"
+
+# IPv4 addresses #
+readonly IPv4octet_RegEx="([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])"
+readonly IPv4addrs_RegEx="${IPv4octet_RegEx}([.]$IPv4octet_RegEx){3}"
+readonly IPv4privt1_RegEx="10([.]$IPv4octet_RegEx){3}"
+readonly IPv4privt2_RegEx="192[.]168([.]$IPv4octet_RegEx){2}"
+readonly IPv4privt3_RegEx="172[.](1[6-9]|2[0-9]|3[01])([.]$IPv4octet_RegEx){2}"
+readonly IPv4privtx_RegEx="($IPv4privt1_RegEx|$IPv4privt2_RegEx|$IPv4privt3_RegEx)"
+
+# NVRAM IP Address Reservations #
+readonly NVRAM_3004_DHCPvar_RegExp="dhcp_staticlist=[<]?${MACaddr_RegEx}>.+"
+readonly NVRAM_3006_DHCPvar_RegExp0="dhcpres[1-9][0-9]?_rl="
+readonly NVRAM_3006_DHCPvar_RegExp1="${NVRAM_3006_DHCPvar_RegExp0}<${MACaddr_RegEx}>.+"
+
+readonly addnDHCP_HostNames=false
+readonly guestNetInfoJSfileName="GuestNetworkSubnetInfo.js"
+readonly guestNetInfoJSfilePath="${SCRIPT_DIR}/$guestNetInfoJSfileName"
+readonly dhcpGuestNetAllowVarKey="allowGuestNet_IPaddr_Reservations"
+readonly dhcpGuestNetConfigFName="DHCP_GuestNetInfo.conf"
+readonly dhcpGuestNetConfigFPath="${SCRIPT_DIR}/$dhcpGuestNetConfigFName"
+readonly guestNetCheckJSfileName="GuestNetCheckStatus.js"
+readonly guestNetCheckJSfilePath="${SCRIPT_WEB_DIR}/$guestNetCheckJSfileName"
 
 ##----------------------------------------------##
 ## Added/modified by Martinski W. [2023-May-28] ##
@@ -97,19 +140,20 @@ readonly SCRIPT_DHCP_LEASE_CONF="${SCRIPT_DIR}/$DHCP_LEASE_FILE"
 ##----------------------------------------------##
 ## Start of script variables for the "Save Custom User Icons" feature ##
 ##--------------------------------------------------------------------##
-readonly theJFFSdir="/jffs"
+readonly JFFS_Dir="/jffs"
+readonly JFFS_Configs_Dir="/jffs/configs"
 readonly userIconsDIRname="usericon"
-readonly userIconsDIRpath="${theJFFSdir}/$userIconsDIRname"
+readonly userIconsDIRpath="${JFFS_Dir}/$userIconsDIRname"
 readonly userIconsSavedFLEextn="tar.gzip"
 readonly userIconsSavedFLEname="CustomUserIcons"
 readonly userIconsSavedDIRname="SavedUserIcons"
 readonly userIconsSavedCFGname="CustomUserIconsConfig"
 readonly userIconsSavedSTAname="CustomUserIconsStatus"
 readonly defUserIconsBackupDir="/opt/var/$userIconsSavedDIRname"
-readonly altUserIconsBackupDir="/jffs/configs/$userIconsSavedDIRname"
+readonly altUserIconsBackupDir="${JFFS_Configs_Dir}/$userIconsSavedDIRname"
 readonly userIconsVarPrefix="Icons_"
 readonly savedFileDateTimeStr="%Y-%m-%d_%H-%M-%S"
-readonly NVRAM_Folder="${theJFFSdir}/nvram"
+readonly NVRAM_Folder="${JFFS_Dir}/nvram"
 readonly NVRAM_ClientsKeyName="custom_clientlist"
 readonly NVRAM_ClientsKeyVARsaved="${userIconsDIRpath}/NVRAMvar_${NVRAM_ClientsKeyName}.TMP"
 readonly NVRAM_ClientsKeyFLEsaved="${userIconsDIRpath}/NVRAMfile_${NVRAM_ClientsKeyName}.TMP"
@@ -131,6 +175,8 @@ readonly BOLDtext="\e[1m"
 readonly LghtRED="\e[1;31m"
 readonly LghtGREEN="\e[1;32m"
 readonly MGNTct="\e[1;35m"
+readonly GRAYct="\e[0;37m"
+readonly GRAYEDct="\e[0;30;47m"
 readonly REDct="${LghtRED}${BOLDtext}"
 readonly GRNct="${LghtGREEN}${BOLDtext}"
 readonly WarnBYLWct="\e[30;103m"
@@ -156,13 +202,23 @@ theBackupFilesMatch="${userIconsBackupFPath}_*.$userIconsSavedFLEextn"
 ## End of script variables for the "Save Custom User Icons" feature ##
 ##==================================================================##
 
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+# Remove all "color escape sequences" from the system log file entries #
+_RemoveColorEscapeSequences_()
+{
+    if [ $# -eq 0 ] || [ -z "$1" ] ; then return echo ; fi
+    echo "$1" | sed 's/\\e\[[0-1]m//g; s/\\e\[[3-4][0-9]m//g; s/\\e\[[0-1];[3-4][0-9]m//g; s/\\e\[30;10[1-9]m//g; s/\\n/ /g'
+}
+
 ##----------------------------------------##
-## Modified by Martinski W. [2025-Mar-16] ##
+## Modified by Martinski W. [2025-Sep-05] ##
 ##----------------------------------------##
 # $1 = print to syslog, $2 = message to print, $3 = log level
 Print_Output()
 {
-	local prioStr  prioNum
+	local prioStr  prioNum  logMsg
 	if [ $# -gt 2 ] && [ -n "$3" ]
 	then prioStr="$3"
 	else prioStr="NOTICE"
@@ -176,25 +232,25 @@ Print_Output()
 		    "$PASS") prioNum=6 ;; #INFO#
 		          *) prioNum=5 ;; #NOTICE#
 		esac
-		logger -t "${SCRIPT_NAME}_[$$]" -p $prioNum "$2"
+		logMsg="$(_RemoveColorEscapeSequences_ "$2")"
+		printf "$logMsg" | logger -t "${SCRIPT_NAME}_[$$]" -p $prioNum
 	fi
-	printf "${BOLD}${3}%s${CLEARct}\n\n" "$2"
+	printf "${BOLD}${3}${2}${CLRct}\n"
+	if [ $# -lt 4 ] || [ "$4" != "oneline" ]
+	then echo ; fi
 }
 
 Firmware_Version_Check()
 {
-	if nvram get rc_support | grep -qF "am_addons"; then
-		return 0
-	else
-		return 1
+	if nvram get rc_support | grep -qF "am_addons"
+	then return 0
+	else return 1
 	fi
 }
 
 ### Code for this function courtesy of https://github.com/decoderman- credit to @thelonelycoder ###
-Firmware_Version_Number()
+FirmwareVersionNum()
 { echo "$1" | awk -F. '{ printf("%d%03d%03d%02d\n", $1,$2,$3,$4); }' ; }
-
-############################################################################
 
 ### Code for these functions inspired by https://github.com/Adamm00 - credit to @Adamm ###
 Check_Lock()
@@ -211,10 +267,13 @@ Check_Lock()
 			return 0
 		else
 			Print_Output true "Lock file found (age: $ageoflock seconds) - stopping to prevent duplicate runs" "$ERR"
-			if [ -z "$1" ]; then
+			if [ $# -eq 0 ] || [ -z "$1" ]
+			then
 				exit 1
 			else
-				if [ "$1" = "webui" ]; then
+				if [ "$1" = "webui" ]
+				then
+					_Update_GuestNetCheck_Status_ LOCKED
 					exit 1
 				fi
 				return 1
@@ -226,11 +285,22 @@ Check_Lock()
 	fi
 }
 
-Clear_Lock(){
+Clear_Lock()
+{
 	rm -f "/tmp/$SCRIPT_NAME.lock" 2>/dev/null
 	return 0
 }
-############################################################################
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-07] ##
+##-------------------------------------##
+_GetFileSizeBytes_()
+{
+    if [ $# -eq 0 ] || [ -z "$1" ] || [ ! -s "$1" ]
+    then echo 0 ; return 0
+    fi
+    ls -1l "$1" | awk -F ' ' '{print $3}'
+}
 
 Validate_IP()
 {
@@ -299,7 +369,7 @@ DHCP_LeaseValueToSeconds()
 ##----------------------------------------------##
 Check_DHCP_LeaseTime()
 {
-   NVRAM_LeaseTime="$(nvram get $DHCP_LEASE_KEYN)"
+   NVRAM_LeaseTime="$(nvram get "$DHCP_LEASE_KEYN")"
 
    if [ ! -f "$SCRIPT_DHCP_LEASE_CONF" ]
    then
@@ -583,72 +653,93 @@ Check_CustomUserIconsConfig()
    GetUserIconsSavedVars
 }
 
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+BackUpConfigSettings()
+{
+	if [ -f "$SHARED_CUSTOM_CONFIG_FILE" ]
+	then
+		cp -fp "$SHARED_CUSTOM_CONFIG_FILE" "$SHARED_CUSTOM_CONFIG_BACKUP"
+	fi
+}
+
 ##----------------------------------------##
-## Modified by Martinski W. [2024-Feb-26] ##
+## Modified by Martinski W. [2025-Sep-05] ##
 ##----------------------------------------##
 Conf_FromSettings()
 {
-	SETTINGSFILE="/jffs/addons/custom_settings.txt"
-	TMPFILE="/tmp/yazdhcp_clients.tmp"
+	SETTINGSFILE="$SHARED_CUSTOM_CONFIG_FILE"
+	TEMP_FILE="/tmp/yazdhcp_clients.tmp"
+	PARSED_FILE="/tmp/yazdhcp_clients_parsed.tmp"
+
 	if [ -f "$SETTINGSFILE" ]
 	then
-		if [ "$(grep -E "yazdhcp_|^$YazDHCP_LEASEtag" $SETTINGSFILE | grep -v "version" -c)" -gt 0 ]
+		if [ "$(grep -cE "^(yazdhcp_client|$YazDHCP_LEASEtag)" $SETTINGSFILE)" -gt 0 ]
 		then
 			Print_Output true "Updated DHCP information from WebUI found, merging into $SCRIPT_CONF" "$PASS"
-			cp -a "$SCRIPT_CONF" "$SCRIPT_CONF.bak"
-			grep -E "yazdhcp_|^$YazDHCP_LEASEtag" "$SETTINGSFILE" | grep -v "version" > "$TMPFILE"
-			sed -i "s/yazdhcp_//g;s/ /=/g" "$TMPFILE"
+			cp -a "$SCRIPT_CONF" "${SCRIPT_CONF}.bak"
+			grep -E "^(yazdhcp_client|$YazDHCP_LEASEtag)" "$SETTINGSFILE" > "$TEMP_FILE"
+			sed -i "s/^yazdhcp_//g;s/ /=/g" "$TEMP_FILE"
 			DHCPCLIENTS=""
 			while IFS='' read -r line || [ -n "$line" ]
 			do
 				if echo "$line" | grep -q "^${YazDHCP_LEASEtag}="
 				then
-					LEASE_VALUE="$(echo "$line" | cut -d '=' -f2)"
+					LEASE_VALUE="$(echo "$line" | cut -d'=' -f2)"
 					sed -i "s/DHCP_LEASE=.*/DHCP_LEASE=$LEASE_VALUE/" "$SCRIPT_DHCP_LEASE_CONF"
 					continue
 				fi
-				DHCPCLIENTS="${DHCPCLIENTS}$(echo "$line" | cut -f2 -d'=')"
-			done < "$TMPFILE"
+				DHCPCLIENTS="${DHCPCLIENTS}$(echo "$line" | cut -d'=' -f2)"
+			done < "$TEMP_FILE"
 
-			echo "$DHCPCLIENTS" | sed 's/|/:/g;s/></\n/g;s/>/ /g;s/<//g' > /tmp/yazdhcp_clients_parsed.tmp
+			echo "$DHCPCLIENTS" | sed 's/|/:/g;s/></\n/g;s/>/ /g;s/<//g' > "$PARSED_FILE"
 
-			RESTART_DNSMASQ=false
-			DO_NVRAM_COMMIT=false
-			echo "MAC,IP,HOSTNAME,DNS" > "$SCRIPT_CONF"
-
-			while IFS='' read -r line || [ -n "$line" ]
-			do
-				if ! CheckAgainstNVRAMvar "$line" ; then DO_NVRAM_COMMIT=true ; fi
-				if [ "$(echo "$line" | wc -w)" -eq 4 ]; then
-					echo "$line" | awk '{ print ""$1","$2","$3","$4""; }' >> "$SCRIPT_CONF"
-				elif [ "$(echo "$line" | wc -w)" -gt 1 ]; then
-					if [ "$(echo "$line" | cut -d " " -f3 | wc -L)" -eq 0 ]; then
-						echo "$line" | awk '{ print ""$1","$2","","$3""; }' >> "$SCRIPT_CONF"
-					else
-						printf "%s,\\n" "$(echo "$line" | sed 's/ /,/g')" >> "$SCRIPT_CONF"
-					fi
-				fi
-			done < /tmp/yazdhcp_clients_parsed.tmp
-
-			LANSUBNET="$(nvram get lan_ipaddr | cut -d'.' -f1-3)"
-			LANNETMASK="$(nvram get lan_netmask)"
-			if [ "$LANNETMASK" = "255.255.255.0" ]; then
-				awk -F "," -v lansub="$LANSUBNET" 'FNR==1{print $0; next} BEGIN {OFS = ","} $2=lansub"."$2' "$SCRIPT_CONF" > "$SCRIPT_CONF.tmp"
-			else
-				cp "$SCRIPT_CONF" "$SCRIPT_CONF.tmp"
-			fi
-			sort -t . -k 3,3n -k 4,4n "$SCRIPT_CONF.tmp" > "$SCRIPT_CONF"
-			rm -f "$SCRIPT_CONF.tmp"
-
-			grep 'yazdhcp_version' "$SETTINGSFILE" > "$TMPFILE"
+			grep -E '^yazdhcp_Vers[LS]' "$SETTINGSFILE" > "$TEMP_FILE"
 			sed -i "\\~yazdhcp_~d" "$SETTINGSFILE"
 			sed -i "\\~${YazDHCP_LEASEtag}~d" "$SETTINGSFILE"
-			mv "$SETTINGSFILE" "$SETTINGSFILE.bak"
-			cat "$SETTINGSFILE.bak" "$TMPFILE" > "$SETTINGSFILE"
-			rm -f /tmp/yazdhcp*
-			rm -f "$SETTINGSFILE.bak"
+			mv -f "$SETTINGSFILE" "${SETTINGSFILE}.bak"
+			cat "${SETTINGSFILE}.bak" "$TEMP_FILE" > "$SETTINGSFILE"
+			rm -f "${SETTINGSFILE}.bak" "$TEMP_FILE"
 
-			ProcessDHCPClients "$DO_NVRAM_COMMIT"
+			LAN_SUBNET="$(echo "$mainLAN_IPaddr" | cut -d'.' -f1-3)"
+			RESTART_DNSMASQ=false
+			DO_NVRAM_COMMIT=false
+
+			echo "MAC,IP,HOSTNAME,DNS" > "$SCRIPT_CONF"
+
+			while IFS='' read -r theLine || [ -n "$theLine" ]
+			do
+				theLine="$(Check_IPv4_AddressValue "$theLine")"
+				if ! CheckAgainstNVRAMvar "$theLine"
+				then DO_NVRAM_COMMIT=true
+				fi
+				if [ "$(echo "$theLine" | wc -w)" -eq 4 ]
+				then
+					echo "$theLine" | awk -F' ' '{ print ""$1","$2","$3","$4""; }' >> "$SCRIPT_CONF"
+				elif [ "$(echo "$theLine" | wc -w)" -gt 1 ]
+				then
+					if [ "$(echo "$theLine" | cut -d " " -f3 | wc -L)" -eq 0 ]
+					then
+						echo "$theLine" | awk -F' ' '{ print ""$1","$2","","$3""; }' >> "$SCRIPT_CONF"
+					else
+						printf "%s,\n" "$(echo "$theLine" | sed 's/ /,/g')" >> "$SCRIPT_CONF"
+					fi
+				fi
+			done < "$PARSED_FILE"
+
+			cp -fp "$SCRIPT_CONF" "${SCRIPT_CONF}.tmp"
+			sort -t . -k 3,3n -k 4,4n "${SCRIPT_CONF}.tmp" > "$SCRIPT_CONF"
+			rm -f "${SCRIPT_CONF}.tmp" "$PARSED_FILE"
+
+			if [ -s "${SCRIPT_CONF}.bak" ] && \
+			   ! diff "$SCRIPT_CONF" "${SCRIPT_CONF}.bak" >/dev/null 2>&1
+			then RESTART_DNSMASQ=true
+			else RESTART_DNSMASQ="$DO_NVRAM_COMMIT"
+			fi
+			Process_DHCP_Clients
+
 			Check_DHCP_LeaseTime
 			if "$DO_NVRAM_COMMIT" ; then nvram commit ; fi
 
@@ -658,54 +749,102 @@ Conf_FromSettings()
 			then
 				Print_Output true "Restarting dnsmasq for new DHCP settings to take effect." "$PASS"
 				## Delay restarting dnsmasq until the one from WebGUI is completed ##
-				(sleep 2 ; service restart_dnsmasq >/dev/null 2>&1) &
+				(sleep 3 ; service restart_dnsmasq >/dev/null 2>&1) &
 			fi
 		else
 			Print_Output false "No updated DHCP information from WebUI found, no merge into $SCRIPT_CONF necessary" "$PASS"
 		fi
+		if [ -s "$SHARED_CUSTOM_CONFIG_BACKUP" ]
+		then
+			mv -f "$SHARED_CUSTOM_CONFIG_BACKUP" "$SHARED_CUSTOM_CONFIG_FILE"
+		fi
+		rm -f "$SHARED_CUSTOM_CONFIG_BACKUP"
 	fi
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2025-Mar-17] ##
+## Modified by Martinski W. [2025-Sep-05] ##
 ##----------------------------------------##
 Set_Version_Custom_Settings()
 {
-	SETTINGSFILE="/jffs/addons/custom_settings.txt"
+	SETTINGSFILE="$SHARED_CUSTOM_CONFIG_FILE"
 	case "$1" in
 		local)
-			if [ -f "$SETTINGSFILE" ]
+			if [ -s "$SETTINGSFILE" ]
 			then
 				if [ "$(grep -c "^yazdhcp_version_local" "$SETTINGSFILE")" -gt 0 ]
 				then
-					if [ "$SCRIPT_VERSION" != "$(grep "^yazdhcp_version_local" "$SETTINGSFILE" | cut -f2 -d' ')" ]
+					sed -i "s/^yazdhcp_version_local/yazdhcp_VersLocal/" "$SETTINGSFILE"
+				fi
+				if [ "$(grep -c "^yazdhcp_version_server" "$SETTINGSFILE")" -gt 0 ]
+				then
+					sed -i "s/^yazdhcp_version_server/yazdhcp_VersServer/" "$SETTINGSFILE"
+				fi
+				if [ "$(grep -c "^yazdhcp_VersLocal" "$SETTINGSFILE")" -gt 0 ]
+				then
+					if [ "$SCRIPT_VERSION" != "$(grep "^yazdhcp_VersLocal" "$SETTINGSFILE" | cut -d' ' -f2)" ]
 					then
-						sed -i "s/^yazdhcp_version_local.*/yazdhcp_version_local $SCRIPT_VERSION/" "$SETTINGSFILE"
+						sed -i "s/^yazdhcp_VersLocal.*/yazdhcp_VersLocal $SCRIPT_VERSION/" "$SETTINGSFILE"
 					fi
 				else
-					echo "yazdhcp_version_local $SCRIPT_VERSION" >> "$SETTINGSFILE"
+					echo "yazdhcp_VersLocal $SCRIPT_VERSION" >> "$SETTINGSFILE"
 				fi
 			else
-				echo "yazdhcp_version_local $SCRIPT_VERSION" >> "$SETTINGSFILE"
+				echo "yazdhcp_VersLocal $SCRIPT_VERSION" >> "$SETTINGSFILE"
 			fi
 		;;
 		server)
-			if [ -f "$SETTINGSFILE" ]
+			if [ -s "$SETTINGSFILE" ]
 			then
 				if [ "$(grep -c "^yazdhcp_version_server" "$SETTINGSFILE")" -gt 0 ]
 				then
-					if [ "$2" != "$(grep "^yazdhcp_version_server" "$SETTINGSFILE" | cut -f2 -d' ')" ]
+					sed -i "s/^yazdhcp_version_server/yazdhcp_VersServer/" "$SETTINGSFILE"
+				fi
+				if [ "$(grep -c "^yazdhcp_VersServer" "$SETTINGSFILE")" -gt 0 ]
+				then
+					if [ "$2" != "$(grep "^yazdhcp_VersServer" "$SETTINGSFILE" | cut -d' ' -f2)" ]
 					then
-						sed -i "s/^yazdhcp_version_server.*/yazdhcp_version_server $2/" "$SETTINGSFILE"
+						sed -i "s/^yazdhcp_VersServer.*/yazdhcp_VersServer $2/" "$SETTINGSFILE"
 					fi
 				else
-					echo "yazdhcp_version_server $2" >> "$SETTINGSFILE"
+					echo "yazdhcp_VersServer $2" >> "$SETTINGSFILE"
 				fi
 			else
-				echo "yazdhcp_version_server $2" >> "$SETTINGSFILE"
+				echo "yazdhcp_VersServer $2" >> "$SETTINGSFILE"
+			fi
+		;;
+		delete)
+			if [ -s "$SETTINGSFILE" ]
+			then
+				sed -i '/yazdhcp_VersLocal/d' "$SETTINGSFILE"
+				sed -i '/yazdhcp_VersServer/d' "$SETTINGSFILE"
 			fi
 		;;
 	esac
+}
+
+##----------------------------------------##
+## Modified by Martinski W. [2025-Sep-05] ##
+##----------------------------------------##
+Download_File()
+{
+	if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ]
+	then return 1
+	fi
+	local tempFilePathDL="${2}.DWLD.TMP"
+
+	curl -LSs --retry 4 --retry-delay 5 --retry-connrefused \
+	     "$1" -o "$tempFilePathDL"
+	if [ $? -ne 0 ] || [ ! -s "$tempFilePathDL" ] || \
+	   grep -iq "^404: Not Found" "$tempFilePathDL"
+	then
+		Print_Output true "**ERROR**: Unable to download file [$2] for $SCRIPT_NAME." "$ERR"
+		rm -f "$tempFilePathDL"
+		return 1
+	else
+		mv -f "$tempFilePathDL" "$2"
+		return 0
+	fi
 }
 
 ##----------------------------------------##
@@ -715,29 +854,29 @@ Update_Check()
 {
 	echo 'var updatestatus = "InProgress";' > "$SCRIPT_WEB_DIR/detect_update.js"
 	doupdate="false"
-	localver="$(grep "SCRIPT_VERSION=" /jffs/scripts/"$SCRIPT_NAME" | grep -m1 -oE "$scriptVersRegExp")"
+	localVer="$(grep "SCRIPT_VERSION=" /jffs/scripts/"$SCRIPT_NAME" | grep -m1 -oE "$scriptVersRegExp")"
 	curl -fsL --retry 4 --retry-delay 5 "$SCRIPT_REPO/$SCRIPT_NAME.sh" | grep -qF "jackyaz" || \
-	{ Print_Output true "404 error detected - stopping update" "$ERR"; return 1; }
-	serverver="$(curl -fsL --retry 4 --retry-delay 5 "$SCRIPT_REPO/$SCRIPT_NAME.sh" | grep "SCRIPT_VERSION=" | grep -m1 -oE "$scriptVersRegExp")"
-	if [ "$localver" != "$serverver" ]
+	{ Print_Output true "404 error detected - stopping update" "$ERR" ; return 1 ; }
+	serverVer="$(curl -fsL --retry 4 --retry-delay 5 "$SCRIPT_REPO/$SCRIPT_NAME.sh" | grep "SCRIPT_VERSION=" | grep -m1 -oE "$scriptVersRegExp")"
+	if [ "$localVer" != "$serverVer" ]
 	then
 		doupdate="version"
-		Set_Version_Custom_Settings server "$serverver"
-		echo 'var updatestatus = "'"$serverver"'";'  > "$SCRIPT_WEB_DIR/detect_update.js"
+		Set_Version_Custom_Settings server "$serverVer"
+		echo 'var updatestatus = "'"$serverVer"'";'  > "$SCRIPT_WEB_DIR/detect_update.js"
 	else
 		localmd5="$(md5sum "/jffs/scripts/$SCRIPT_NAME" | awk '{print $1}')"
 		remotemd5="$(curl -fsL --retry 4 --retry-delay 5 "$SCRIPT_REPO/$SCRIPT_NAME.sh" | md5sum | awk '{print $1}')"
 		if [ "$localmd5" != "$remotemd5" ]
 		then
 			doupdate="md5"
-			Set_Version_Custom_Settings server "$serverver-hotfix"
-			echo 'var updatestatus = "'"$serverver-hotfix"'";'  > "$SCRIPT_WEB_DIR/detect_update.js"
+			Set_Version_Custom_Settings server "${serverVer}-hotfix"
+			echo 'var updatestatus = "'"${serverVer}-hotfix"'";'  > "$SCRIPT_WEB_DIR/detect_update.js"
 		fi
 	fi
 	if [ "$doupdate" = "false" ]; then
 		echo 'var updatestatus = "None";' > "$SCRIPT_WEB_DIR/detect_update.js"
 	fi
-	echo "$doupdate,$localver,$serverver"
+	echo "$doupdate,$localVer,$serverVer"
 }
 
 ##----------------------------------------##
@@ -749,13 +888,15 @@ Update_Version()
 	then
 		updatecheckresult="$(Update_Check)"
 		isupdate="$(echo "$updatecheckresult" | cut -f1 -d',')"
-		localver="$(echo "$updatecheckresult" | cut -f2 -d',')"
-		serverver="$(echo "$updatecheckresult" | cut -f3 -d',')"
+		localVer="$(echo "$updatecheckresult" | cut -f2 -d',')"
+		serverVer="$(echo "$updatecheckresult" | cut -f3 -d',')"
 
-		if [ "$isupdate" = "version" ]; then
-			Print_Output true "New version of $SCRIPT_NAME available - updating to $serverver" "$PASS"
-		elif [ "$isupdate" = "md5" ]; then
-			Print_Output true "MD5 hash of $SCRIPT_NAME does not match - downloading updated $serverver" "$PASS"
+		if [ "$isupdate" = "version" ]
+		then
+			Print_Output true "New version of $SCRIPT_NAME available - updating to $serverVer" "$PASS"
+		elif [ "$isupdate" = "md5" ]
+		then
+			Print_Output true "MD5 hash of $SCRIPT_NAME does not match - downloading updated $serverVer" "$PASS"
 		fi
 
 		Update_File shared-jy.tar.gz
@@ -766,9 +907,9 @@ Update_Version()
 
 			Download_File "$SCRIPT_REPO/$SCRIPT_NAME.sh" "/jffs/scripts/$SCRIPT_NAME" && \
 			Print_Output true "$SCRIPT_NAME successfully updated" "$PASS"
-			chmod 0755 /jffs/scripts/"$SCRIPT_NAME"
+			[ -s "/jffs/scripts/$SCRIPT_NAME" ] && chmod 0755 "/jffs/scripts/$SCRIPT_NAME"
 			Clear_Lock
-			if [ -z "$1" ]
+			if [ $# -eq 0 ] || [ -z "$1" ]
 			then
 				exec "$0" setversion
 			elif [ "$1" = "unattended" ]
@@ -777,20 +918,20 @@ Update_Version()
 			fi
 			exit 0
 		else
-			Print_Output true "No new version - latest is $localver" "$WARN"
+			Print_Output true "No new version - latest is $localVer" "$WARN"
 			Clear_Lock
 		fi
 	fi
 
 	if [ $# -gt 0 ] && [ "$1" = "force" ]
 	then
-		serverver="$(curl -fsL --retry 4 --retry-delay 5 "$SCRIPT_REPO/$SCRIPT_NAME.sh" | grep "SCRIPT_VERSION=" | grep -m1 -oE "$scriptVersRegExp")"
-		Print_Output true "Downloading latest version ($serverver) of $SCRIPT_NAME" "$PASS"
+		serverVer="$(curl -fsL --retry 4 --retry-delay 5 "$SCRIPT_REPO/$SCRIPT_NAME.sh" | grep "SCRIPT_VERSION=" | grep -m1 -oE "$scriptVersRegExp")"
+		Print_Output true "Downloading latest version ($serverVer) of $SCRIPT_NAME" "$PASS"
 		Update_File Advanced_DHCP_Content.asp
 		Update_File shared-jy.tar.gz
 		Download_File "$SCRIPT_REPO/$SCRIPT_NAME.sh" "/jffs/scripts/$SCRIPT_NAME" && \
 		Print_Output true "$SCRIPT_NAME successfully updated" "$PASS"
-		chmod 0755 /jffs/scripts/"$SCRIPT_NAME"
+		[ -s "/jffs/scripts/$SCRIPT_NAME" ] && chmod 0755 "/jffs/scripts/$SCRIPT_NAME"
 		Clear_Lock
 		if [ $# -lt 2 ] || [ -z "$2" ]
 		then
@@ -804,44 +945,45 @@ Update_Version()
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2025-Mar-16] ##
+## Modified by Martinski W. [2025-Sep-05] ##
 ##----------------------------------------##
 Update_File()
 {
 	if [ "$1" = "Advanced_DHCP_Content.asp" ]
 	then
-		tmpfile="/tmp/$1"
+		webUIupdateOK=true
+		local tmpfile="/tmp/$1"
 		if [ -f "$SCRIPT_DIR/$1" ]
 		then
 			Download_File "$SCRIPT_REPO/$1" "$tmpfile"
 			if ! diff -q "$tmpfile" "$SCRIPT_DIR/$1" >/dev/null 2>&1
 			then
-				Download_File "$SCRIPT_REPO/$1" "$SCRIPT_DIR/$1"
+				Download_File "$SCRIPT_REPO/$1" "$SCRIPT_DIR/$1" && \
 				Print_Output true "New version of $1 downloaded" "$PASS"
 				Mount_WebUI
 			fi
 			rm -f "$tmpfile"
 		else
-			Download_File "$SCRIPT_REPO/$1" "$SCRIPT_DIR/$1"
+			Download_File "$SCRIPT_REPO/$1" "$SCRIPT_DIR/$1" && \
 			Print_Output true "New version of $1 downloaded" "$PASS"
 			Mount_WebUI
 		fi
 	elif [ "$1" = "shared-jy.tar.gz" ]
 	then
-		if [ ! -f "$SHARED_DIR/$1.md5" ]
+		if [ ! -f "$SHARED_DIR/${1}.md5" ]
 		then
 			Download_File "$SHARED_REPO/$1" "$SHARED_DIR/$1"
-			Download_File "$SHARED_REPO/$1.md5" "$SHARED_DIR/$1.md5"
+			Download_File "$SHARED_REPO/${1}.md5" "$SHARED_DIR/${1}.md5"
 			tar -xzf "$SHARED_DIR/$1" -C "$SHARED_DIR"
 			rm -f "$SHARED_DIR/$1"
 			Print_Output true "New version of $1 downloaded" "$PASS"
 		else
-			localmd5="$(cat "$SHARED_DIR/$1.md5")"
-			remotemd5="$(curl -fsL --retry 4 --retry-delay 5 "$SHARED_REPO/$1.md5")"
+			localmd5="$(cat "$SHARED_DIR/${1}.md5")"
+			remotemd5="$(curl -fsL --retry 4 --retry-delay 5 "$SHARED_REPO/${1}.md5")"
 			if [ "$localmd5" != "$remotemd5" ]
 			then
 				Download_File "$SHARED_REPO/$1" "$SHARED_DIR/$1"
-				Download_File "$SHARED_REPO/$1.md5" "$SHARED_DIR/$1.md5"
+				Download_File "$SHARED_REPO/${1}.md5" "$SHARED_DIR/${1}.md5"
 				tar -xzf "$SHARED_DIR/$1" -C "$SHARED_DIR"
 				rm -f "$SHARED_DIR/$1"
 				Print_Output true "New version of $1 downloaded" "$PASS"
@@ -871,28 +1013,410 @@ Create_Dirs()
 	fi
 }
 
-##----------------------------------------------##
-## Added/modified by Martinski W. [2023-May-28] ##
-##----------------------------------------------##
-Create_DHCP_LeaseConfig()
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+_CheckForWirelessRadioEnabled_()
 {
-   Check_DHCP_LeaseTime && nvram commit
-   ln -sf "$SCRIPT_DHCP_LEASE_CONF" "${SCRIPT_WEB_DIR}/${DHCP_LEASE_FILE}.htm" 2>/dev/null
+    local wifiRadioEnabled=false
+    local wifiIFname  wifiRadioStatus
+
+    if [ -z "$wifiIFnameList" ]
+    then
+        printf "\nWiFi Interface List *NOT* found.\n"
+        return 1
+    fi
+    for wifiIFname in $wifiIFnameList
+    do
+        wifiRadioStatus="$(wl -i "$wifiIFname" bss 2>/dev/null)"
+        if [ "$wifiRadioStatus" = "up" ]
+        then
+            wifiRadioEnabled=true
+            break
+        fi
+    done
+    "$wifiRadioEnabled" && return 0 || return 1
 }
 
-##----------------------------------------------##
-## Added/modified by Martinski W. [2023-Apr-16] ##
-##----------------------------------------------##
-Create_CustomUserIconsConfig()
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+_Get_ActiveGuestNetwork_VirtualInterfaces_()
 {
-   Check_CustomUserIconsConfig
-   ln -sf "$SCRIPT_USER_ICONS_CONFIG" "${SCRIPT_WEB_DIR}/${userIconsSavedCFGname}.htm" 2>/dev/null
-   ln -sf "$SCRIPT_USER_ICONS_STATUS" "${SCRIPT_WEB_DIR}/${userIconsSavedSTAname}.htm" 2>/dev/null
-   ln -sf "$SCRIPT_USER_ICONS_BKPLST" "${SCRIPT_WEB_DIR}/${userIconsSavedBKPList}.htm" 2>/dev/null
+    local gnInfoStr1  gnInfoStr2  gnInfoNum1  gnInfoNum2
+    gnListOfIFaces=""
+
+    gnInfoStr1="$(ifconfig | grep -E "^$guestNetIFaces1RegExp")"
+    gnInfoStr2="$(ip route show | grep -E "$guestNetIFaces2RegExp")"
+
+    if ! _CheckForWirelessRadioEnabled_ && \
+       [ "${#gnInfoStr1}" -eq 0 ] && [ "${#gnInfoStr2}" -eq 0 ]
+    then return 1
+    fi
+
+    gnInfoNum1="$(echo "$gnInfoStr1" | wc -l)"
+    gnInfoNum2="$(echo "$gnInfoStr2" | wc -l)"
+
+    if [ "${#gnInfoStr1}" -gt 0 ] && \
+       [ "${#gnInfoStr2}" -gt 0 ] && \
+       [ "$gnInfoNum1" -eq "$gnInfoNum2" ]
+    then
+        gnListOfIFaces="$(echo "$gnInfoStr1" | awk -F' ' '{print $1}')"
+    else
+        gnListOfIFaces="$(echo "$gnInfoStr2" | awk -F' ' '{print $3}')"
+    fi
+    [ -n "$gnListOfIFaces" ] && return 0 || return 1
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+_Init_GuestNetworkAllow_VarsConfig_()
+{
+   echo "${dhcpGuestNetAllowVarKey}=false" > "$dhcpGuestNetConfigFPath"
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+_Init_GuestNetCheck_Status_()
+{
+   echo "var guestNetCheckStatus = 'INIT';" > "$guestNetCheckJSfilePath"
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Aug-30] ##
+##-------------------------------------##
+gnCheckCallLevel=0
+gnCheckLastStatusID="INIT"
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+_Update_GuestNetCheck_Status_()
+{
+    if [ $# -eq 0 ] || [ -z "$1" ]
+    then return 1
+    fi
+    if [ ! -s "$guestNetCheckJSfilePath" ]
+    then
+        _Init_GuestNetCheck_Status_
+    fi
+
+    case "$1" in
+        DONE)
+            [ "$gnCheckCallLevel" -gt 0 ] && \
+            gnCheckCallLevel="$((gnCheckCallLevel - 1))"
+            ;;
+        InProgress)
+            gnCheckCallLevel="$((gnCheckCallLevel + 1))"
+            ;;
+    esac
+
+    if { [ "$1" = "DONE" ] && [ "$gnCheckCallLevel" -gt 0 ] ; } || \
+       grep -qE "guestNetCheckStatus = '$1';" "$guestNetCheckJSfilePath" || \
+       { [ "$1" = "INIT" ] && [ "$gnCheckLastStatusID" = "InProgress" ] ; }
+    then return 0
+    fi
+    gnCheckLastStatusID="$1"
+    echo "var guestNetCheckStatus = '$1';" > "$guestNetCheckJSfilePath"
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+_Init_ActiveGuestNetwork_SubnetInfo_()
+{
+   {
+      echo 'var foundActiveGuestNetworks = false;'
+      echo 'var allowGuestNet_IP_Reservation = false;'
+      echo 'var guestNetwork_SubnetInfoArray = [];' 
+   } > "$guestNetInfoJSfilePath"
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-06] ##
+##-------------------------------------##
+_Is_DHCP_Static_IPs_Enabled_()
+{
+   if [ "$(nvram get dhcp_static_x)" = "1" ]
+   then
+       echo "true" ; return 0
+   else
+       echo "false" ; return 1
+   fi
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+_Set_FoundActiveGuestNetworks_()
+{
+   if [ $# -eq 0 ] || [ -z "$1" ] || \
+      ! echo "$1" | grep -qE '^(true|false)$' || \
+      [ ! -s "$guestNetInfoJSfilePath" ]
+   then
+       _Init_ActiveGuestNetwork_SubnetInfo_
+       return 1
+   fi
+
+   if ! grep -qE '^var foundActiveGuestNetworks =' "$guestNetInfoJSfilePath"
+   then
+       sed -i "1 i var foundActiveGuestNetworks = ${1};" "$guestNetInfoJSfilePath"
+   else
+       sed -i "s/^var foundActiveGuestNetworks =.*/var foundActiveGuestNetworks = ${1};/" "$guestNetInfoJSfilePath"
+   fi
+   return 0
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+_Set_AllowGuestNetwork_IP_Reservations_()
+{
+    if [ $# -eq 0 ] || [ -z "$1" ] || \
+       ! echo "$1" | grep -qE '^(true|false)$' || \
+       [ ! -s "$guestNetInfoJSfilePath" ]
+    then
+        _Init_ActiveGuestNetwork_SubnetInfo_
+        return 1
+    fi
+
+    if ! grep -qE '^var allowGuestNet_IP_Reservation =' "$guestNetInfoJSfilePath"
+    then
+        sed -i "2 i var allowGuestNet_IP_Reservation = ${1};" "$guestNetInfoJSfilePath"
+    else
+        sed -i "s/^var allowGuestNet_IP_Reservation =.*/var allowGuestNet_IP_Reservation = ${1};/" "$guestNetInfoJSfilePath"
+    fi
+
+    if "$1"
+    then _Check_ActiveGuestNetwork_SubnetInfo_
+    fi
+    return 0
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+_AllowGuestNetwork_IP_Reservations_()
+{
+    if [ $# -eq 0 ] || [ -z "$1" ]
+    then return 1
+    fi
+    local setVerboseMode=true  prevStatusFlag="NONE"
+
+    [ "$1" != "check" ] && _Update_GuestNetCheck_Status_ INIT
+
+    if [ $# -gt 1 ] && [ -n "$2" ] && \
+       echo "$2" | grep -qE "^(true|false)$"
+    then setVerboseMode="$2"
+    fi
+
+    if [ ! -s "$dhcpGuestNetConfigFPath" ] || \
+       ! grep -qE "^${dhcpGuestNetAllowVarKey}=(true|false)$" "$dhcpGuestNetConfigFPath"
+    then
+        _Init_GuestNetworkAllow_VarsConfig_
+    elif [ "$1" != "check" ]
+    then
+        prevStatusFlag="$(_AllowGuestNetwork_IP_Reservations_ check)"
+    fi
+
+    case "$1" in
+        check)
+            grep -E "^${dhcpGuestNetAllowVarKey}=.*" "$dhcpGuestNetConfigFPath" | cut -d'=' -f2
+            ;;
+        reset)
+            echo "${dhcpGuestNetAllowVarKey}=false" > "$dhcpGuestNetConfigFPath"
+            _Update_GuestNetCheck_Status_ InProgress
+            _Set_AllowGuestNetwork_IP_Reservations_ false
+            if [ "$prevStatusFlag" != "false" ] || \
+               ! "$(_Is_DHCP_Static_IPs_Enabled_)"
+            then Process_DHCP_Clients true
+            fi
+            _Update_GuestNetCheck_Status_ DONE
+            ;;
+        enable)
+            sed -i "s/^${dhcpGuestNetAllowVarKey}=.*/${dhcpGuestNetAllowVarKey}=true/" "$dhcpGuestNetConfigFPath"
+            _Update_GuestNetCheck_Status_ InProgress
+            _Set_AllowGuestNetwork_IP_Reservations_ true
+            if [ "$prevStatusFlag" != "true" ]
+            then Process_DHCP_Clients true
+            fi
+            _Update_GuestNetCheck_Status_ DONE
+            ;;
+        disable)
+            sed -i "s/^${dhcpGuestNetAllowVarKey}=.*/${dhcpGuestNetAllowVarKey}=false/" "$dhcpGuestNetConfigFPath"
+            _Update_GuestNetCheck_Status_ InProgress
+            _Set_AllowGuestNetwork_IP_Reservations_ false
+            if [ "$prevStatusFlag" != "false" ] || \
+               ! "$(_Is_DHCP_Static_IPs_Enabled_)"
+            then Process_DHCP_Clients true
+            fi
+            _Update_GuestNetCheck_Status_ DONE
+            ;;
+    esac
+
+    return 0
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+_Get_DHCP_NetworkTagStr_()
+{
+    if [ $# -eq 0 ] || [ -z "$1" ]
+    then echo ; return 1
+    fi
+    local dnsmasqFileStr="/etc/dnsmasq.conf"  theIPaddr3
+    local dnsmasqFilePath  dhcpOptionStr  dhcpRangeStr  dhcpNoIFaceID
+
+    if [ "$fwInstalledBaseVers" -ge 3006 ] && \
+       { [ $# -lt 2 ] || [ "$2" != "MainLAN" ] ; }
+    then dnsmasqFileStr="/etc/dnsmasq*.conf"
+    fi
+    dnsmasqIndxNum=""
+    dhcpNetwkTagID=""
+    theIPaddr3="$(echo "$1" | cut -d'.' -f1-3)"
+
+    for dnsmasqFile in $(ls -1 $dnsmasqFileStr 2>/dev/null)
+    do
+        dhcpRangeStr="$(grep -E "^dhcp-range=.*,${theIPaddr3}[.].*," "$dnsmasqFile")"
+        dhcpOptionStr="$(grep -E "^dhcp-option=.*,(3|option:router),$1" "$dnsmasqFile")"
+        dhcpNoIFaceID="$(grep -E "^no-dhcp-interface=$2" "$dnsmasqFile")"
+        if [ -z "$dhcpOptionStr" ] && [ -z "$dhcpRangeStr" ] && [ -z "$dhcpNoIFaceID" ]
+        then continue
+        fi
+        if [ -n "$dhcpOptionStr" ]
+        then
+            dhcpNetwkTagID="$(echo "$dhcpOptionStr" | cut -d'=' -f2 | cut -d',' -f1)"
+            if echo "$dhcpNetwkTagID" | grep -qE "^tag:.*"
+            then
+                dhcpNetwkTagID="$(echo "$dhcpNetwkTagID" | cut -d':' -f2)"
+            fi
+        fi
+        if [ -z "$dhcpNetwkTagID" ] && [ -n "$dhcpRangeStr" ]
+        then
+            dhcpNetwkTagID="$(echo "$dhcpRangeStr" | cut -d'=' -f2 | cut -d',' -f1)"
+            if echo "$dhcpNetwkTagID" | grep -qE "^set:.*"
+            then
+                dhcpNetwkTagID="$(echo "$dhcpNetwkTagID" | cut -d':' -f2)"
+            fi
+        fi
+        if echo "$dnsmasqFile" | grep -qE '/etc/dnsmasq-[1-9][0-9]?.conf'
+        then
+            dnsmasqIndxNum="$(echo "$dnsmasqFile" | cut -d'-' -f2 | cut -d'.' -f1)"
+        fi
+        if [ -z "$dhcpNetwkTagID" ] && [ -n "$dhcpNoIFaceID" ]
+        then
+            [ "$fwInstalledBaseVers" -ge 3006 ] && \
+            dhcpNetwkTagID="$(echo "$dhcpNoIFaceID" | cut -d'=' -f2)"
+            dnsmasqIndxNum=ZERO   #NO DHCP Interface#
+        fi
+    done
+
+    [ -z "$dhcpNetwkTagID" ] && dhcpNetwkTagID=NONE
+    [ -z "$dnsmasqIndxNum" ] && dnsmasqIndxNum=ZERO
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+_Add_GuestNetwork_SubnetInfo_()
+{
+    local gnIFaceVarStr="GNIFACE_${gnIFaceName}"
+    local gnIFaceInfoDef  dhcpNetwkTagID=NONE  dnsmasqIndxNum=ZERO
+
+    _Get_DHCP_NetworkTagStr_ "$gnStartIPadd" "$gnIFaceName"
+    gnIFaceInfoDef="${gnIFaceVarStr}=${gnStartIPadd},${gnSubnetMask},${gnSubnetCIDR},${dhcpNetwkTagID},${dnsmasqIndxNum}"
+
+    if [ "$dhcpNetwkTagID" = "NONE" ] || \
+       { [ "$fwInstalledBaseVers" -ge 3006 ] && [ "$dnsmasqIndxNum" = "ZERO" ] ; }
+    then
+        if grep -qE "^${gnIFaceVarStr}=.*" "$dhcpGuestNetConfigFPath" 
+        then
+            sed -i "/^${gnIFaceVarStr}=.*/d" "$dhcpGuestNetConfigFPath"
+        fi
+        return 1
+    fi
+    if grep -qE "^${gnIFaceInfoDef}$" "$dhcpGuestNetConfigFPath"
+    then return 0
+    fi
+    if ! grep -qE "^${gnIFaceVarStr}=.*" "$dhcpGuestNetConfigFPath" 
+    then
+        echo "$gnIFaceInfoDef" >> "$dhcpGuestNetConfigFPath"
+    else
+        sed -i "s~^${gnIFaceVarStr}=.*~${gnIFaceInfoDef}~" "$dhcpGuestNetConfigFPath"
+    fi
+    return 0
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-06] ##
+##-------------------------------------##
+_Reset_GuestNetwork_SubnetInfo_()
+{
+    if [ ! -s "$dhcpGuestNetConfigFPath" ] || \
+       ! grep -qE "^GNIFACE_${guestNetIFaces0RegExp}=" "$dhcpGuestNetConfigFPath"
+    then return 0
+    fi
+    sed -i '/^GNIFACE_.*=.*/d' "$dhcpGuestNetConfigFPath"
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+_Get_GuestNetwork_SubnetInfo_()
+{
+    if [ ! -s "$dhcpGuestNetConfigFPath" ] || \
+       ! grep -qE "^GNIFACE_${guestNetIFaces0RegExp}=" "$dhcpGuestNetConfigFPath"
+    then echo ; return 1
+    fi
+    grep -E "^GNIFACE_${guestNetIFaces0RegExp}=.*" "$dhcpGuestNetConfigFPath"
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+Create_DHCP_GuestNetworkConfig()
+{
+    if [ ! -s "$dhcpGuestNetConfigFPath" ] || \
+       ! grep -qE "^${dhcpGuestNetAllowVarKey}=(true|false)$" "$dhcpGuestNetConfigFPath"
+    then
+        _Init_GuestNetworkAllow_VarsConfig_
+    fi
+    if [ ! -s "$guestNetInfoJSfilePath" ]
+    then
+        _Init_ActiveGuestNetwork_SubnetInfo_
+    fi
+    if [ ! -s "$guestNetCheckJSfilePath" ]
+    then
+        _Init_GuestNetCheck_Status_
+    fi
+    ln -sf "$guestNetInfoJSfilePath" "${SCRIPT_WEB_DIR}/$guestNetInfoJSfileName" 2>/dev/null
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2023-Apr-01] ##
+## Modified by Martinski W. [2023-May-28] ##
+##----------------------------------------##
+Create_DHCP_LeaseConfig()
+{
+    Check_DHCP_LeaseTime && nvram commit
+    ln -sf "$SCRIPT_DHCP_LEASE_CONF" "${SCRIPT_WEB_DIR}/${DHCP_LEASE_FILE}.htm" 2>/dev/null
+}
+
+##----------------------------------------##
+## Modified by Martinski W. [2023-Apr-16] ##
+##----------------------------------------##
+Create_CustomUserIconsConfig()
+{
+    Check_CustomUserIconsConfig
+    ln -sf "$SCRIPT_USER_ICONS_CONFIG" "${SCRIPT_WEB_DIR}/${userIconsSavedCFGname}.htm" 2>/dev/null
+    ln -sf "$SCRIPT_USER_ICONS_STATUS" "${SCRIPT_WEB_DIR}/${userIconsSavedSTAname}.htm" 2>/dev/null
+    ln -sf "$SCRIPT_USER_ICONS_BKPLST" "${SCRIPT_WEB_DIR}/${userIconsSavedBKPList}.htm" 2>/dev/null
+}
+
+##----------------------------------------##
+## Modified by Martinski W. [2025-Sep-05] ##
 ##----------------------------------------##
 Create_Symlinks()
 {
@@ -901,6 +1425,7 @@ Create_Symlinks()
 	ln -s "$SCRIPT_CONF" "$SCRIPT_WEB_DIR/DHCP_clients.htm" 2>/dev/null
 	Create_DHCP_LeaseConfig
 	Create_CustomUserIconsConfig
+	Create_DHCP_GuestNetworkConfig
 
 	if [ ! -d "$SHARED_WEB_DIR" ]; then
 		ln -s "$SHARED_DIR" "$SHARED_WEB_DIR" 2>/dev/null
@@ -908,37 +1433,41 @@ Create_Symlinks()
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2023-Mar-14] ##
+## Modified by Martinski W. [2025-Aug-23] ##
 ##----------------------------------------##
 Auto_ServiceEvent()
 {
-	case $1 in
+	local theScriptFilePath="/jffs/scripts/$SCRIPT_NAME"
+	case "$1" in
 		create)
 			if [ -f /jffs/scripts/service-event ]
 			then
-				STARTUPLINECOUNT=$(grep -c '# '"$SCRIPT_NAME" /jffs/scripts/service-event)
-				STARTUPLINECOUNTEX=$(grep -cx 'if echo "$2" | /bin/grep -q "'"$SCRIPT_NAME"'" ; then { /jffs/scripts/'"$SCRIPT_NAME"' service_event "$@" & }; fi # '"$SCRIPT_NAME" /jffs/scripts/service-event)
+				STARTUPLINECOUNT="$(grep -c '# '"$SCRIPT_NAME" /jffs/scripts/service-event)"
+				STARTUPLINECOUNTEX="$(grep -cx 'if echo "$2" | /bin/grep -q "'"$SCRIPT_NAME"'" || { \[ "$1" = "restart" \] && \[ "$2" = "wireless" \]; }; then { '"$theScriptFilePath"' service_event "$@" & }; fi # '"$SCRIPT_NAME" /jffs/scripts/service-event)"
 
 				if [ "$STARTUPLINECOUNT" -gt 1 ] || { [ "$STARTUPLINECOUNTEX" -eq 0 ] && [ "$STARTUPLINECOUNT" -gt 0 ]; }
 				then
 					sed -i -e '/# '"$SCRIPT_NAME"'/d' /jffs/scripts/service-event
 				fi
-
-				if [ "$STARTUPLINECOUNTEX" -eq 0 ]; then
-					echo 'if echo "$2" | /bin/grep -q "'"$SCRIPT_NAME"'" ; then { /jffs/scripts/'"$SCRIPT_NAME"' service_event "$@" & }; fi # '"$SCRIPT_NAME" >> /jffs/scripts/service-event
+				if [ "$STARTUPLINECOUNTEX" -eq 0 ]
+				then
+					{
+					   echo 'if echo "$2" | /bin/grep -q "'"$SCRIPT_NAME"'" || { [ "$1" = "restart" ] && [ "$2" = "wireless" ]; }; then { '"$theScriptFilePath"' service_event "$@" & }; fi # '"$SCRIPT_NAME"
+					} >> /jffs/scripts/service-event
 				fi
 			else
-				echo "#!/bin/sh" > /jffs/scripts/service-event
-				echo "" >> /jffs/scripts/service-event
-				echo 'if echo "$2" | /bin/grep -q "'"$SCRIPT_NAME"'" ; then { /jffs/scripts/'"$SCRIPT_NAME"' service_event "$@" & }; fi # '"$SCRIPT_NAME" >> /jffs/scripts/service-event
+				{
+				   echo "#!/bin/sh" ; echo
+				   echo 'if echo "$2" | /bin/grep -q "'"$SCRIPT_NAME"'" || { [ "$1" = "restart" ] && [ "$2" = "wireless" ]; }; then { '"$theScriptFilePath"' service_event "$@" & }; fi # '"$SCRIPT_NAME"
+				   echo
+				} > /jffs/scripts/service-event
 				chmod 0755 /jffs/scripts/service-event
 			fi
 		;;
 		delete)
 			if [ -f /jffs/scripts/service-event ]
 			then
-				STARTUPLINECOUNT=$(grep -c '# '"$SCRIPT_NAME" /jffs/scripts/service-event)
-
+				STARTUPLINECOUNT="$(grep -c '# '"$SCRIPT_NAME" /jffs/scripts/service-event)"
 				if [ "$STARTUPLINECOUNT" -gt 0 ]; then
 					sed -i -e '/# '"$SCRIPT_NAME"'/d' /jffs/scripts/service-event
 				fi
@@ -953,29 +1482,29 @@ Auto_Startup()
 		create)
 			if [ -f /jffs/scripts/services-start ]
 			then
-				STARTUPLINECOUNT=$(grep -c '# '"$SCRIPT_NAME" /jffs/scripts/services-start)
-				STARTUPLINECOUNTEX=$(grep -cx "/jffs/scripts/$SCRIPT_NAME startup"' "$@" & # '"$SCRIPT_NAME" /jffs/scripts/services-start)
+				STARTUPLINECOUNT="$(grep -c '# '"$SCRIPT_NAME" /jffs/scripts/services-start)"
+				STARTUPLINECOUNTEX="$(grep -cx "/jffs/scripts/$SCRIPT_NAME startup"' "$@" & # '"$SCRIPT_NAME" /jffs/scripts/services-start)"
 
 				if [ "$STARTUPLINECOUNT" -gt 1 ] || { [ "$STARTUPLINECOUNTEX" -eq 0 ] && [ "$STARTUPLINECOUNT" -gt 0 ]; }
 				then
 					sed -i -e '/# '"$SCRIPT_NAME"'/d' /jffs/scripts/services-start
 				fi
-
 				if [ "$STARTUPLINECOUNTEX" -eq 0 ]; then
 					echo "/jffs/scripts/$SCRIPT_NAME startup"' "$@" & # '"$SCRIPT_NAME" >> /jffs/scripts/services-start
 				fi
 			else
-				echo "#!/bin/sh" > /jffs/scripts/services-start
-				echo "" >> /jffs/scripts/services-start
-				echo "/jffs/scripts/$SCRIPT_NAME startup"' "$@" & # '"$SCRIPT_NAME" >> /jffs/scripts/services-start
+				{
+				   echo "#!/bin/sh" ; echo
+				   echo "/jffs/scripts/$SCRIPT_NAME startup"' "$@" & # '"$SCRIPT_NAME"
+				   echo
+				} > /jffs/scripts/services-start
 				chmod 0755 /jffs/scripts/services-start
 			fi
 		;;
 		delete)
 			if [ -f /jffs/scripts/services-start ]
 			then
-				STARTUPLINECOUNT=$(grep -c '# '"$SCRIPT_NAME" /jffs/scripts/services-start)
-
+				STARTUPLINECOUNT="$(grep -c '# '"$SCRIPT_NAME" /jffs/scripts/services-start)"
 				if [ "$STARTUPLINECOUNT" -gt 0 ]; then
 					sed -i -e '/# '"$SCRIPT_NAME"'/d' /jffs/scripts/services-start
 				fi
@@ -985,144 +1514,455 @@ Auto_Startup()
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2024-Feb-26] ##
+## Modified by Martinski W. [2025-Sep-05] ##
 ##----------------------------------------##
-Auto_DNSMASQ()
+Auto_DNSMASQ_Handler()
 {
-	if [ $# -eq 0 ] || [ -z "$1" ] ; then return 1 ; fi
-
-	if [ $# -gt 1 ] && [ "$2" = "false" ]
-	then doRESTART=false
-	else doRESTART=true
+	if [ $# -eq 0 ] || [ -z "$1" ]
+	then return 1
 	fi
+	local theCommenTagStr  configAddFileTEMP  configAddFileORIG
+	configAddFileORIG="${configAddFilePath}.ORIG.BKUP"
 
 	case $1 in
 		create)
-			entryDeleted=0
-			CONFCHANGED="false"
-			ADDN_HOSTSFILE="addn-hosts=$SCRIPT_DIR/.hostnames # ${SCRIPT_NAME}_hostnames"
-			DHCP_HOSTSFILE="dhcp-hostsfile=$SCRIPT_DIR/.staticlist # ${SCRIPT_NAME}_staticlist"
-			DHCP_OPTS_FILE="dhcp-optsfile=$SCRIPT_DIR/.optionslist # ${SCRIPT_NAME}_optionslist"
+			configAddFileTEMP="${configAddFilePath}.TEMP.BKUP"
 
-			if [ -f /jffs/configs/dnsmasq.conf.add ]
+			if [ -s "$configAddFileORIG" ]
 			then
-				STARTUPLINECOUNT="$(grep -c "# ${SCRIPT_NAME}_hostnames" /jffs/configs/dnsmasq.conf.add)"
-				STARTUPLINECOUNTEX="$(grep -cx "$ADDN_HOSTSFILE" /jffs/configs/dnsmasq.conf.add)"
-
+				cp -fp "$configAddFileORIG" "$configAddFileTEMP"
+				#---------------------------------------------------------------------------#
+				theCommenTagStr="# $ADDN_HostsComntTag"
+				STARTUPLINECOUNT="$(grep -c "$theCommenTagStr" "$configAddFileORIG")"
+				if [ "$STARTUPLINECOUNT" -gt 0 ]
+				then
+					sed -i -e "/${theCommenTagStr}/d" "$configAddFileORIG"
+				fi
+				theCommenTagStr="#${ADDN_HostsComntTag}#"
+				STARTUPLINECOUNT="$(grep -c "$theCommenTagStr" "$configAddFileORIG")"
+				STARTUPLINECOUNTEX="$(grep -cx "$ADDN_HostsDirctive" "$configAddFileORIG")"
 				if [ "$STARTUPLINECOUNT" -gt 1 ] || \
 				   { [ "$STARTUPLINECOUNTEX" -eq 0 ] && [ "$STARTUPLINECOUNT" -gt 0 ] ; } || \
-				   { [ ! -s "$SCRIPT_DIR/.hostnames" ] && [ "$STARTUPLINECOUNT" -gt 0 ] ; }
+				   { [ ! -s "$ADDN_HostsFilePath" ] && [ "$STARTUPLINECOUNT" -gt 0 ] ; }
 				then
-					sed -i -e '/# '"${SCRIPT_NAME}_hostnames"'/d' /jffs/configs/dnsmasq.conf.add
-					entryDeleted="$((entryDeleted | 0x01))"
+					sed -i -e "/${theCommenTagStr}/d" "$configAddFileORIG"
+				fi
+				STARTUPLINECOUNTEX="$(grep -cx "$ADDN_HostsDirctive" "$configAddFileORIG")"
+				if [ "$STARTUPLINECOUNTEX" -eq 0 ] && [ -s "$ADDN_HostsFilePath" ]
+				then
+					echo "$ADDN_HostsDirctive" >> "$configAddFileORIG"
+					dnsmasqConfigCHANGED=true
 				fi
 
-				STARTUPLINECOUNTEX="$(grep -cx "$ADDN_HOSTSFILE" /jffs/configs/dnsmasq.conf.add)"
-				if [ "$STARTUPLINECOUNTEX" -eq 0 ] && [ -s "$SCRIPT_DIR/.hostnames" ]
+				#---------------------------------------------------------------------------#
+				theCommenTagStr="# $DHCP_HostsComntTag"
+				STARTUPLINECOUNT="$(grep -c "$theCommenTagStr" "$configAddFileORIG")"
+				if [ "$STARTUPLINECOUNT" -gt 0 ]
 				then
-					echo "$ADDN_HOSTSFILE" >> /jffs/configs/dnsmasq.conf.add
-					CONFCHANGED="true"
-					entryDeleted="$((entryDeleted & (~0x01)))"
+					sed -i -e "/${theCommenTagStr}/d" "$configAddFileORIG"
 				fi
-
-				STARTUPLINECOUNT="$(grep -c "# ${SCRIPT_NAME}_staticlist" /jffs/configs/dnsmasq.conf.add)"
-				STARTUPLINECOUNTEX="$(grep -cx "$DHCP_HOSTSFILE" /jffs/configs/dnsmasq.conf.add)"
-
+				theCommenTagStr="#${DHCP_HostsComntTag}#"
+				STARTUPLINECOUNT="$(grep -c "$theCommenTagStr" "$configAddFileORIG")"
+				STARTUPLINECOUNTEX="$(grep -cx "$DHCP_HostsDirctive" "$configAddFileORIG")"
 				if [ "$STARTUPLINECOUNT" -gt 1 ] || \
 				   { [ "$STARTUPLINECOUNTEX" -eq 0 ] && [ "$STARTUPLINECOUNT" -gt 0 ] ; } || \
-				   { [ ! -s "$SCRIPT_DIR/.staticlist" ] && [ "$STARTUPLINECOUNT" -gt 0 ] ; }
+				   { [ ! -s "$DHCP_HostsFilePath" ] && [ "$STARTUPLINECOUNT" -gt 0 ] ; }
 				then
-					sed -i -e '/# '"${SCRIPT_NAME}_staticlist"'/d' /jffs/configs/dnsmasq.conf.add
-					entryDeleted="$((entryDeleted | 0x02))"
+					sed -i -e "/${theCommenTagStr}/d" "$configAddFileORIG"
+				fi
+				STARTUPLINECOUNTEX="$(grep -cx "$DHCP_HostsDirctive" "$configAddFileORIG")"
+				if [ "$STARTUPLINECOUNTEX" -eq 0 ] && [ -s "$DHCP_HostsFilePath" ]
+				then
+					echo "$DHCP_HostsDirctive" >> "$configAddFileORIG"
+					dnsmasqConfigCHANGED=true
 				fi
 
-				STARTUPLINECOUNTEX="$(grep -cx "$DHCP_HOSTSFILE" /jffs/configs/dnsmasq.conf.add)"
-				if [ "$STARTUPLINECOUNTEX" -eq 0 ] && [ -s "$SCRIPT_DIR/.staticlist" ]
+				#---------------------------------------------------------------------------#
+				theCommenTagStr="# $DHCP_OptnsComntTag"
+				STARTUPLINECOUNT="$(grep -c "$theCommenTagStr" "$configAddFileORIG")"
+				if [ "$STARTUPLINECOUNT" -gt 0 ]
 				then
-					echo "$DHCP_HOSTSFILE" >> /jffs/configs/dnsmasq.conf.add
-					CONFCHANGED="true"
-					entryDeleted="$((entryDeleted & (~0x02)))"
+					sed -i -e "/${theCommenTagStr}/d" "$configAddFileORIG"
 				fi
-
-				STARTUPLINECOUNT="$(grep -c "# ${SCRIPT_NAME}_optionslist" /jffs/configs/dnsmasq.conf.add)"
-				STARTUPLINECOUNTEX="$(grep -cx "$DHCP_OPTS_FILE" /jffs/configs/dnsmasq.conf.add)"
-
+				theCommenTagStr="#${DHCP_OptnsComntTag}#"
+				STARTUPLINECOUNT="$(grep -c "$theCommenTagStr" "$configAddFileORIG")"
+				STARTUPLINECOUNTEX="$(grep -cx "$DHCP_OptnsDirctive" "$configAddFileORIG")"
 				if [ "$STARTUPLINECOUNT" -gt 1 ] || \
 				   { [ "$STARTUPLINECOUNTEX" -eq 0 ] && [ "$STARTUPLINECOUNT" -gt 0 ] ; } || \
-				   { [ ! -s "$SCRIPT_DIR/.optionslist" ] && [ "$STARTUPLINECOUNT" -gt 0 ] ; }
+				   { [ ! -s "$DHCP_OptnsFilePath" ] && [ "$STARTUPLINECOUNT" -gt 0 ] ; }
 				then
-					sed -i -e '/# '"${SCRIPT_NAME}_optionslist"'/d' /jffs/configs/dnsmasq.conf.add
-					entryDeleted="$((entryDeleted | 0x04))"
+					sed -i -e "/${theCommenTagStr}/d" "$configAddFileORIG"
 				fi
-
-				STARTUPLINECOUNTEX="$(grep -cx "$DHCP_OPTS_FILE" /jffs/configs/dnsmasq.conf.add)"
-				if [ "$STARTUPLINECOUNTEX" -eq 0 ] && [ -s "$SCRIPT_DIR/.optionslist" ]
+				STARTUPLINECOUNTEX="$(grep -cx "$DHCP_OptnsDirctive" "$configAddFileORIG")"
+				if [ "$STARTUPLINECOUNTEX" -eq 0 ] && [ -s "$DHCP_OptnsFilePath" ]
 				then
-					echo "$DHCP_OPTS_FILE" >> /jffs/configs/dnsmasq.conf.add
-					CONFCHANGED="true"
-					entryDeleted="$((entryDeleted & (~0x04)))"
+					echo "$DHCP_OptnsDirctive" >> "$configAddFileORIG"
+					dnsmasqConfigCHANGED=true
 				fi
-				[ "$((entryDeleted & 0x07))" -gt 0 ] && CONFCHANGED="true"
+				#---------------------------------------------------------------------------#
+				if [ ! -s "$configAddFileORIG" ] || \
+				   ! diff "$configAddFileTEMP" "$configAddFileORIG" >/dev/null 2>&1
+				then
+					dnsmasqConfigCHANGED=true
+				fi
+				[ -s "$configAddFileORIG" ] && \
+				mv -f "$configAddFileORIG" "$configAddFilePath" 2>/dev/null
+				rm -f "$configAddFileTEMP" "$configAddFileORIG"
 			else
 				{
-				  echo ""
-				  [ -s "$SCRIPT_DIR/.hostnames" ] && echo "$ADDN_HOSTSFILE"
-				  [ -s "$SCRIPT_DIR/.staticlist" ] && echo "$DHCP_HOSTSFILE"
-				  [ -s "$SCRIPT_DIR/.optionslist" ] && echo "$DHCP_OPTS_FILE"
-				} >> /jffs/configs/dnsmasq.conf.add
-				chmod 0644 /jffs/configs/dnsmasq.conf.add
-				CONFCHANGED="true"
+				   [ -s "$ADDN_HostsFilePath" ] && echo "$ADDN_HostsDirctive"
+				   [ -s "$DHCP_HostsFilePath" ] && echo "$DHCP_HostsDirctive"
+				   [ -s "$DHCP_OptnsFilePath" ] && echo "$DHCP_OptnsDirctive"
+				} > "$configAddFilePath"
+				if [ -s "$configAddFilePath" ]
+				then 
+					dnsmasqConfigCHANGED=true
+					chmod 0644 "$configAddFilePath"
+				fi
 			fi
-			"$CONFCHANGED" && "$doRESTART" && service restart_dnsmasq >/dev/null 2>&1
+			[ ! -s "$configAddFilePath" ] && rm -f "$configAddFilePath"
 		;;
 		delete)
-			if [ -f /jffs/configs/dnsmasq.conf.add ]
+			if [ -s "$configAddFileORIG" ]
 			then
-				CONFCHANGED="false"
-				STARTUPLINECOUNT=$(grep -c "# ${SCRIPT_NAME}_hostnames" /jffs/configs/dnsmasq.conf.add)
-
-				if [ "$STARTUPLINECOUNT" -gt 0 ]; then
-					sed -i -e '/# '"${SCRIPT_NAME}_hostnames"'/d' /jffs/configs/dnsmasq.conf.add
-					CONFCHANGED="true"
+				theCommenTagStr="#${ADDN_HostsComntTag}#"
+				STARTUPLINECOUNT="$(grep -c "$theCommenTagStr" "$configAddFileORIG")"
+				if [ "$STARTUPLINECOUNT" -gt 0 ]
+				then
+					sed -i -e "/${theCommenTagStr}/d" "$configAddFileORIG"
+					dnsmasqConfigCHANGED=true
+				fi
+				theCommenTagStr="# $ADDN_HostsComntTag"
+				STARTUPLINECOUNT="$(grep -c "$theCommenTagStr" "$configAddFileORIG")"
+				if [ "$STARTUPLINECOUNT" -gt 0 ]
+				then
+					sed -i -e "/${theCommenTagStr}/d" "$configAddFileORIG"
+					dnsmasqConfigCHANGED=true
 				fi
 
-				STARTUPLINECOUNT=$(grep -c "# ${SCRIPT_NAME}_staticlist" /jffs/configs/dnsmasq.conf.add)
-
-				if [ "$STARTUPLINECOUNT" -gt 0 ]; then
-					sed -i -e '/# '"${SCRIPT_NAME}_staticlist"'/d' /jffs/configs/dnsmasq.conf.add
-					CONFCHANGED="true"
+				#-------------------------------------------------------------------------#
+				theCommenTagStr="#${DHCP_HostsComntTag}#"
+				STARTUPLINECOUNT="$(grep -c "$theCommenTagStr" "$configAddFileORIG")"
+				if [ "$STARTUPLINECOUNT" -gt 0 ]
+				then
+					sed -i -e "/${theCommenTagStr}/d" "$configAddFileORIG"
+					dnsmasqConfigCHANGED=true
+				fi
+				theCommenTagStr="# $DHCP_HostsComntTag"
+				STARTUPLINECOUNT="$(grep -c "$theCommenTagStr" "$configAddFileORIG")"
+				if [ "$STARTUPLINECOUNT" -gt 0 ]
+				then
+					sed -i -e "/${theCommenTagStr}/d" "$configAddFileORIG"
+					dnsmasqConfigCHANGED=true
 				fi
 
-				STARTUPLINECOUNT=$(grep -c "# ${SCRIPT_NAME}_optionslist" /jffs/configs/dnsmasq.conf.add)
-
-				if [ "$STARTUPLINECOUNT" -gt 0 ]; then
-					sed -i -e '/# '"${SCRIPT_NAME}_optionslist"'/d' /jffs/configs/dnsmasq.conf.add
-					CONFCHANGED="true"
+				#-------------------------------------------------------------------------#
+				theCommenTagStr="#${DHCP_OptnsComntTag}#"
+				STARTUPLINECOUNT="$(grep -c "$theCommenTagStr" "$configAddFileORIG")"
+				if [ "$STARTUPLINECOUNT" -gt 0 ]
+				then
+					sed -i -e "/${theCommenTagStr}/d" "$configAddFileORIG"
+					dnsmasqConfigCHANGED=true
 				fi
-
-				if [ "$CONFCHANGED" = "true" ]; then
-					service restart_dnsmasq >/dev/null 2>&1
+				theCommenTagStr="# $DHCP_OptnsComntTag"
+				STARTUPLINECOUNT="$(grep -c "$theCommenTagStr" "$configAddFileORIG")"
+				if [ "$STARTUPLINECOUNT" -gt 0 ]
+				then
+					sed -i -e "/${theCommenTagStr}/d" "$configAddFileORIG"
+					dnsmasqConfigCHANGED=true
 				fi
+				[ -s "$configAddFileORIG" ] && \
+				mv -f "$configAddFileORIG" "$configAddFilePath" 2>/dev/null
+				rm -f "$configAddFileORIG"
 			fi
+			[ ! -s "$configAddFilePath" ] && rm -f "$configAddFilePath"
 		;;
 	esac
 }
 
-##----------------------------------------##
-## Modified by Martinski W. [2025-Mar-16] ##
-##----------------------------------------##
-Download_File()
-{ /usr/sbin/curl -LSs --retry 4 --retry-delay 5 --retry-connrefused "$1" -o "$2" ; }
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-13] ##
+##-------------------------------------##
+_SetUp_DNSMasqConfigAddFiles_()
+{
+    if [ "$fwInstalledBaseVers" -lt 3006 ]
+    then return
+    fi
+    local configAddRegExp  configAddFPath  theFName
+
+    configAddRegExp="${JFFS_Configs_Dir}/dnsmasq-*.conf.add"
+    for configAddFPath in $(ls -1 $configAddRegExp 2>/dev/null)
+    do
+        theFName="$(basename "$configAddFPath")"
+        if ! echo "$theFName" | grep -qE '^dnsmasq-[1-9]+[0-9]?.conf.add'
+        then continue
+        fi
+        [ -s "$configAddFPath" ] && \
+        mv -f "$configAddFPath" "${configAddFPath}.ORIG.BKUP"
+        rm -f "$configAddFPath"
+    done
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-14] ##
+##-------------------------------------##
+_CleanUp_DNSMasqConfigFiles_()
+{
+    if [ "$fwInstalledBaseVers" -lt 3006 ]
+    then return
+    fi
+    local gnInfoStr  gnListOfIFaces  gnIFaceName
+    local staticAddRegExp  optionAddRegExp  configAddPrefix
+    local configFPath  confAddFBKUP  configFName  configAddFile
+
+    configAddPrefix="${JFFS_Configs_Dir}/dnsmasq-"
+    staticAddRegExp="dhcp-hostsfile=${SCRIPT_DIR}/.staticlist_"
+    optionAddRegExp="dhcp-optsfile=${SCRIPT_DIR}/.optionslist_"
+
+    _MoveOrDeleteFile_()
+    {
+        if [ -n "$configAddFile" ] && \
+           [ "$(_GetFileSizeBytes_ "$1")" -ge 3 ]
+        then
+            mv -f "$1" "$configAddFile"
+        fi
+        rm -f "$1"
+    }
+
+    for confAddFBKUP in $(ls -1 ${configAddPrefix}*.conf.add.ORIG.BKUP 2>/dev/null)
+    do
+        configFName="$(basename "$confAddFBKUP")"
+        if ! echo "$configFName" | grep -qE '^dnsmasq-[1-9]+[0-9]?.conf.add.ORIG.BKUP'
+        then continue
+        fi
+        configAddFile="$(echo "$confAddFBKUP" | grep -oE "${configAddPrefix}.*.conf.add")"
+        if ! grep -qE "^($staticAddRegExp|$optionAddRegExp).*" "$confAddFBKUP"
+        then
+            _MoveOrDeleteFile_ "$confAddFBKUP"
+            continue
+        fi
+        ## Remove unused YazDHCP custom lines ##
+        sed -i "\\~^${staticAddRegExp}.*~d" "$confAddFBKUP"
+        sed -i "\\~^${optionAddRegExp}.*~d" "$confAddFBKUP"
+        _MoveOrDeleteFile_ "$confAddFBKUP"
+        dnsmasqConfigCHANGED=true
+    done
+
+    gnInfoStr="$(_Get_GuestNetwork_SubnetInfo_)"
+    if [ "${#gnInfoStr}" -eq 0 ]
+    then return 1
+    fi
+    gnListOfIFaces="$(echo "$gnInfoStr" | cut -d'=' -f1 | cut -d'_' -f2)"
+    if [ -z "$gnListOfIFaces" ]
+    then return 1
+    fi
+
+    for configFPATH in $(ls -1 /etc/dnsmasq-*.conf 2>/dev/null)
+    do
+        configFName="$(basename "$configFPATH")"
+        if ! echo "$configFName" | grep -qE '^dnsmasq-[1-9]+[0-9]?.conf'
+        then continue
+        fi
+        configAddFile="${JFFS_Configs_Dir}/${configFName}.add"
+        if ! grep -qE "^($staticAddRegExp|$optionAddRegExp).*" "$configAddFile" 
+        then continue
+        fi
+        isConfigAddFileOK=false
+        for gnIFaceName in $gnListOfIFaces
+        do
+            if grep -qE "^($staticAddRegExp|$optionAddRegExp)$gnIFaceName #" "$configAddFile"
+            then
+                isConfigAddFileOK=true ; break
+            fi
+        done
+        "$isConfigAddFileOK" && continue
+        ## Remove unused YazDHCP custom lines ##
+        sed -i "\\~^${staticAddRegExp}.*~d" "$configFPATH"
+        sed -i "\\~^${optionAddRegExp}.*~d" "$configFPATH"
+        dnsmasqConfigCHANGED=true
+    done
+}
 
 ##----------------------------------------##
-## Modified by Martinski W. [2025-Mar-17] ##
+## Modified by Martinski W. [2025-Sep-14] ##
+##----------------------------------------##
+Auto_DNSMASQ()
+{
+	if [ $# -eq 0 ] || [ -z "$1" ]
+	then return 1
+	fi
+	local doIFaceAction  doIFaceDel
+	local gnInfoStr  gnListOfIFaces  gnIFaceVarStr
+	local gnIFaceName  gnNetwrkTagID  gnNetIndexNum
+	local configAddFilePath  dnsmasqConfigCHANGED  dnsmasqRESTART
+	local ADDN_HostsComntTag  ADDN_HostsFilePath  ADDN_HostsDirctive
+	local DHCP_HostsComntTag  DHCP_HostsFilePath  DHCP_HostsDirctive
+	local DHCP_OptnsComntTag  DHCP_OptnsFilePath  DHCP_OptnsDirctive
+
+	if [ $# -gt 1 ] && [ "$2" = "true" ]
+	then dnsmasqRESTART=true
+	else dnsmasqRESTART=false
+	fi
+	doIFaceAction="$1"
+	dnsmasqConfigCHANGED=false
+
+	_Restart_DNSMASQ_()
+	{
+		if "$dnsmasqConfigCHANGED" || "$dnsmasqRESTART"
+		then
+			Print_Output true "Restarting dnsmasq for new DHCP settings to take effect." "$WARN"
+			service restart_dnsmasq >/dev/null 2>&1
+		fi
+	}
+
+	if ! "$(_Is_DHCP_Static_IPs_Enabled_)"
+	then doIFaceDel=true
+	else doIFaceDel=false
+	fi
+
+	if [ "$1" = "create" ] && "$doIFaceDel"
+	then doIFaceAction=delete
+	fi
+
+	#----------#
+	# Main LAN #
+	#----------#
+	configAddFilePath="${JFFS_Configs_Dir}/dnsmasq.conf.add"
+
+	#----------------#
+	# DHCP Hostnames #
+	#----------------#
+	ADDN_HostsFilePath="$SCRIPT_DIR/.hostnames"
+	ADDN_HostsComntTag="${SCRIPT_NAME}_hostnames"
+	ADDN_HostsDirctive="addn-hosts=$ADDN_HostsFilePath #${ADDN_HostsComntTag}#"
+	if ! "$addnDHCP_HostNames" || "$doIFaceDel"
+	then rm -f "$ADDN_HostsFilePath"
+	fi
+	#-----------------------------------------#
+	# DHCP Hosts with IP Address Reservations #
+	#-----------------------------------------#
+	DHCP_HostsFilePath="$SCRIPT_DIR/.staticlist"
+	DHCP_HostsComntTag="${SCRIPT_NAME}_staticlist"
+	DHCP_HostsDirctive="dhcp-hostsfile=$DHCP_HostsFilePath #${DHCP_HostsComntTag}#"
+	if "$doIFaceDel"
+	then rm -f "$DHCP_HostsFilePath"
+	fi
+	#--------------#
+	# DHCP Options #
+	#--------------#
+	DHCP_OptnsFilePath="$SCRIPT_DIR/.optionslist"
+	DHCP_OptnsComntTag="${SCRIPT_NAME}_optionslist"
+	DHCP_OptnsDirctive="dhcp-optsfile=$DHCP_OptnsFilePath #${DHCP_OptnsComntTag}#"
+	if "$doIFaceDel"
+	then rm -f "$DHCP_OptnsFilePath"
+	fi
+
+	[ -s "$configAddFilePath" ] && \
+	mv -f "$configAddFilePath" "${configAddFilePath}.ORIG.BKUP"
+	rm -f "$configAddFilePath"
+
+	Auto_DNSMASQ_Handler "$doIFaceAction"
+
+	if [ "$fwInstalledBaseVers" -lt 3006 ]
+	then
+		_Restart_DNSMASQ_
+		return 0
+	fi
+
+	gnInfoStr="$(_Get_GuestNetwork_SubnetInfo_)"
+	if [ "${#gnInfoStr}" -eq 0 ]
+	then
+		_Restart_DNSMASQ_
+		return 0
+	fi
+	gnListOfIFaces="$(echo "$gnInfoStr" | cut -d'=' -f1 | cut -d'_' -f2)"
+	if [ -z "$gnListOfIFaces" ]
+	then
+		_Restart_DNSMASQ_
+		return 0
+	fi
+
+	if ! "$(_Is_DHCP_Static_IPs_Enabled_)" || \
+	   ! "$(_AllowGuestNetwork_IP_Reservations_ check)"
+	then doIFaceDel=true
+	else doIFaceDel=false
+	fi
+	if [ "$1" = "create" ] && "$doIFaceDel"
+	then doIFaceAction=delete
+	fi
+
+	#----------------#
+	# Guest Networks #
+	#----------------#
+	_SetUp_DNSMasqConfigAddFiles_
+
+	for gnIFaceName in $gnListOfIFaces
+	do
+		ADDN_HostsFilePath="$SCRIPT_DIR/.hostnames_$gnIFaceName"
+		DHCP_HostsFilePath="$SCRIPT_DIR/.staticlist_$gnIFaceName"
+		DHCP_OptnsFilePath="$SCRIPT_DIR/.optionslist_$gnIFaceName"
+
+		# Get dnsmasq instance number #
+		gnIFaceVarStr="GNIFACE_${gnIFaceName}="
+		gnNetwrkTagID="$(echo "$gnInfoStr" | grep -E "^${gnIFaceVarStr}.*" | cut -d'=' -f2 | cut -d',' -f4)"
+		gnNetIndexNum="$(echo "$gnInfoStr" | grep -E "^${gnIFaceVarStr}.*" | cut -d'=' -f2 | cut -d',' -f5)"
+		if [ -z "$gnNetIndexNum" ] || [ "$gnNetIndexNum" = "ZERO" ]
+		then
+			rm -f "$ADDN_HostsFilePath" "$DHCP_HostsFilePath" "$DHCP_OptnsFilePath"
+			continue
+		fi
+		configAddFilePath="${JFFS_Configs_Dir}/dnsmasq-${gnNetIndexNum}.conf.add"
+
+		#----------------#
+		# DHCP Hostnames #
+		#----------------#
+		ADDN_HostsComntTag="${SCRIPT_NAME}_hostnames_$gnIFaceName"
+		ADDN_HostsDirctive="addn-hosts=$ADDN_HostsFilePath #${ADDN_HostsComntTag}#"
+		if ! "$addnDHCP_HostNames" || "$doIFaceDel"
+		then rm -f "$ADDN_HostsFilePath"
+		fi
+		#-----------------------------------------#
+		# DHCP Hosts with IP Address Reservations #
+		#-----------------------------------------#
+		DHCP_HostsComntTag="${SCRIPT_NAME}_staticlist_$gnIFaceName"
+		DHCP_HostsDirctive="dhcp-hostsfile=$DHCP_HostsFilePath #${DHCP_HostsComntTag}#"
+		if "$doIFaceDel"
+		then rm -f "$DHCP_HostsFilePath"
+		fi
+		#--------------#
+		# DHCP Options #
+		#--------------#
+		DHCP_OptnsComntTag="${SCRIPT_NAME}_optionslist_$gnIFaceName"
+		DHCP_OptnsDirctive="dhcp-optsfile=$DHCP_OptnsFilePath #${DHCP_OptnsComntTag}#"
+		if "$doIFaceDel"
+		then rm -f "$DHCP_OptnsFilePath"
+		fi
+
+		Auto_DNSMASQ_Handler "$doIFaceAction"
+	done
+
+	_CleanUp_DNSMasqConfigFiles_
+	_Restart_DNSMASQ_
+}
+
+##----------------------------------------##
+## Modified by Martinski W. [2025-Sep-05] ##
 ##----------------------------------------##
 Mount_WebUI()
 {
-	Print_Output true "Mounting WebUI tab for $SCRIPT_NAME" "$PASS"
+	Print_Output true "Mounting WebUI tab for ${SCRIPT_NAME}..." "$PASS"
 	umount /www/Advanced_DHCP_Content.asp 2>/dev/null
-	mount -o bind "$SCRIPT_DIR/Advanced_DHCP_Content.asp" /www/Advanced_DHCP_Content.asp
-    Print_Output true "WebUI tab for $SCRIPT_NAME was mounted." "$PASS"
+	if [ -s "$SCRIPT_DIR/Advanced_DHCP_Content.asp" ]
+	then
+		webUIupdateOK=true
+		mount -o bind "$SCRIPT_DIR/Advanced_DHCP_Content.asp" /www/Advanced_DHCP_Content.asp
+		Print_Output true "WebUI tab for $SCRIPT_NAME was mounted." "$PASS"
+		return 0
+	else
+		webUIupdateOK=false
+		Print_Output true "**ERROR**: WebUI file for $SCRIPT_NAME is NOT found." "$ERR"
+		return 1
+	fi
 }
 
 ##-------------------------------------##
@@ -1130,8 +1970,11 @@ Mount_WebUI()
 ##-------------------------------------##
 _CheckFor_WebGUI_Page_()
 {
-   if [ "$(grep -c 'YazDHCP' /www/Advanced_DHCP_Content.asp)" -lt 8 ]
-   then Mount_WebUI ; fi
+	if [ "$(grep -c 'YazDHCP' /www/Advanced_DHCP_Content.asp)" -ge 8 ]
+	then return 0
+	fi
+	Mount_WebUI
+	return "$?"
 }
 
 Shortcut_Script()
@@ -1348,7 +2191,7 @@ CheckForSavedIconFiles()
    backupsFound=true  theBackupFile=""
 
    if [ $# -gt 0 ] && [ -n "$1" ] && "$1"
-   then
+   then   ## Update to the MOST recent backup file ##
        while IFS="$(printf '\n\t')" read -r FILE
        do theBackupFile="$FILE" ; break
        done <<EOT
@@ -1418,7 +2261,7 @@ BackupCustomUserIcons()
    _NVRAM_IconsSaveKeyValue_
 
    theFilePath="${userIconsBackupFPath}_$(date +"$savedFileDateTimeStr").$userIconsSavedFLEextn"
-   if ! tar -czf "$theFilePath" -C "$theJFFSdir" "./$userIconsDIRname"
+   if ! tar -czf "$theFilePath" -C "$JFFS_Dir" "./$userIconsDIRname"
    then
        retCode=1
        UpdateCustomUserIconsConfig SAVED NONE STATUSupdate
@@ -1537,6 +2380,7 @@ _GetFileSelection_()
    done <<EOT
 $(_list2_ -1t "$theBackupFilesMatch" 2>/dev/null)
 EOT
+
    echo
    _GetFileSelectionIndex_ "$fileCount" "$indexType"
 
@@ -1645,7 +2489,7 @@ RestoreUserIconFilesReq()
    fi
    Print_Output true "Restoring icon files from: [${fileIndex}. $theFilePath]" "$PASS"
 
-   if ! tar -xzf "$theFilePath" -C "$theJFFSdir"
+   if ! tar -xzf "$theFilePath" -C "$JFFS_Dir"
    then
        retCode=1
        UpdateCustomUserIconsConfig RESTD NONE STATUSupdate
@@ -1700,7 +2544,7 @@ EOT
        return 99
    fi
 
-   if ! tar -xzf "$theFilePath" -C "$theJFFSdir"
+   if ! tar -xzf "$theFilePath" -C "$JFFS_Dir"
    then
        retCode=99
        UpdateCustomUserIconsConfig RESTD NONE STATUSupdate
@@ -1735,7 +2579,7 @@ ListContentsOfSavedIconsFile()
    then return 1 ; fi
 
    printf "Listing contents of backup file:\n[${GRNct}${theFilePath}${CLRct}]\n\n"
-   if tar -tzf "$theFilePath" -C "$theJFFSdir"
+   if tar -tzf "$theFilePath" -C "$JFFS_Dir"
    then
        retCode=0
        printf "\nContents were listed ${GRNct}successfully${CLRct}.\n"
@@ -1971,7 +2815,7 @@ IconsMenuSelectionHandler()
    do
       while true
       do
-          printf "Choose an option:    " ; read -r userOption
+          printf "Choose an option:  " ; read -r userOption
           if [ -z "$userOption" ] ; then echo ; continue ; fi
 
           if echo "$userOption" | grep -qE "^(e|exit|Exit)$"
@@ -2070,117 +2914,313 @@ RestoreUserIconFiles()
    CheckForCustomIconFiles
 }
 
-##----------------------------------------------##
-## Added/Modified by Martinski W. [2023-Jun-10] ##
-##----------------------------------------------##
+##----------------------------------------------------##
+## Added by Martinski W. [2025-Sep-05]
+##----------------------------------------------------##
+## ARG #1 "$line" has the following format:
+## "{MAC_address} {IP_address} {Hostname} {DNS_IP}"
+## "$line" comes from new DHCP Clients config file
+## so we'll check if the IP address has the octets.
+## If only one add prepend rest from LAN IP address.
+##------------------------------------------------------
+Check_IPv4_AddressValue()
+{
+    if [ $# -eq 0 ] || [ -z "$1" ]
+    then echo ; return 1
+    fi
+    local MACx_Addrs  IPv4_Addrs  theRestStr
+
+    MACx_Addrs="$(echo "$1" | cut -d' ' -f1)"
+    IPv4_Addrs="$(echo "$1" | cut -d' ' -f2)"
+    theRestStr="$(echo "$1" | cut -d' ' -f3-4)"
+
+    if [ "$(echo "$IPv4_Addrs" | awk -F'.' '{print NF-1}')" -eq 0 ]
+    then
+        IPv4_Addrs="${LAN_SUBNET}.$IPv4_Addrs"
+    fi
+    echo "$MACx_Addrs $IPv4_Addrs $theRestStr"
+}
+
+##----------------------------------------------------##
+## Modified by Martinski W. [2025-Sep-05]
+##----------------------------------------------------##
+## ARG #1 "$line" has the following format:
+## "{MAC_address} {IP_address} {Hostname} {DNS_IP}"
+## "$line" comes from new DHCP Clients config file
+## so we'll check for NVRAM variable conflicts.
+## If conflicts are found, NVRAM var is modified.
+## NVRAM variable entry has the following format:
+## "<{MAC_address}>{IP_address}>{DNS_IP}>{Hostname}[<]?"
+##------------------------------------------------------
 CheckAgainstNVRAMvar()
 {
-   if [ $# -eq 0 ] || [ -z "$1" ] ; then return 0 ; fi
+    if [ $# -eq 0 ] || [ -z "$1" ]
+    then return 0
+    fi
+    local theKeyVal  keyEntry  retCode
+    local IPv4_Addrs  theRegExp1
+    local MACx_Addrs  theRegExp2
 
-   if [ ! -s /jffs/nvram/dhcp_staticlist ]
-   then theKeyVal="$(nvram get dhcp_staticlist)"
-   else theKeyVal="$(cat /jffs/nvram/dhcp_staticlist)"
-   fi
-   if [ -z "$theKeyVal" ] ; then return 0 ; fi
-   if ! echo "$theKeyVal" | grep -qE "^<.*"
-   then theKeyVal="<$theKeyVal" ; fi
+    if [ ! -s /jffs/nvram/dhcp_staticlist ]
+    then theKeyVal="$(nvram get dhcp_staticlist)"
+    else theKeyVal="$(cat /jffs/nvram/dhcp_staticlist)"
+    fi
+    if [ -z "$theKeyVal" ]
+    then return 0
+    fi
+    if ! echo "$theKeyVal" | grep -qE "^<.*"
+    then theKeyVal="<$theKeyVal"
+    fi
 
-   retCode=0
-   MACx_Addrs="$(echo "$1" | awk -F ' ' '{print $1}')"
-   IPv4_Addrs="$(echo "$1" | awk -F ' ' '{print $2}')"
-   IPv4_RegEx="([0-9]{1,3}\.){3}([0-9]{1,3})"
-   MACx_RegEx="([a-fA-F0-9]{2}\:){5}([a-fA-F0-9]{2})"
-   theRegExp1="<${MACx_Addrs}>${IPv4_RegEx}>[^<]*"
-   theRegExp2="<${MACx_RegEx}>${IPv4_Addrs}>[^<]*"
-   keyEntry=""
+    retCode=0
+    MACx_Addrs="$(echo "$1" | awk -F ' ' '{print $1}')"
+    IPv4_Addrs="$(echo "$1" | awk -F ' ' '{print $2}')"
+    theRegExp1="<${MACaddr_RegEx}>${IPv4_Addrs}>[^<]*"
+    theRegExp2="<${MACx_Addrs}>${IPv4privtx_RegEx}>[^<]*"
+    keyEntry=""
 
-   if echo "$theKeyVal" | grep -qiE "$theRegExp1"
-   then keyEntry="$(echo "$theKeyVal" | grep -ioE "$theRegExp1")"
-   elif echo "$theKeyVal" | grep -qiE "$theRegExp2"
-   then keyEntry="$(echo "$theKeyVal" | grep -ioE "$theRegExp2")"
-   fi
-   if [ -n "$keyEntry" ]
-   then
-       tempFile="/tmp/yazdhcp_nvramstr.tmp"
-       echo "$theKeyVal" | sed "s/${keyEntry}//g" | sed '/^$/d' > "$tempFile"
-       nvram set dhcp_staticlist="$(cat "$tempFile")"
-       rm -f $tempFile
-       retCode=1
-   fi
-   return $retCode
+    if echo "$theKeyVal" | grep -qE "$theRegExp1"
+    then
+        keyEntry="$(echo "$theKeyVal" | grep -oE "$theRegExp1")"
+    elif echo "$theKeyVal" | grep -qiE "$theRegExp2"
+    then
+        keyEntry="$(echo "$theKeyVal" | grep -oiE "$theRegExp2")"
+    fi
+    if [ -n "$keyEntry" ]
+    then
+        tempFile="/tmp/yazdhcp_nvramStr.tmp"
+        echo "$theKeyVal" | sed "s/${keyEntry}//g" | sed '/^$/d' > "$tempFile"
+        nvram set dhcp_staticlist="$(cat "$tempFile")"
+        rm -f "$tempFile"
+        retCode=1
+    fi
+    return "$retCode"
 }
 
-##----------------------------------------------##
-## Added/Modified by Martinski W. [2023-May-28] ##
-##----------------------------------------------##
-ValidateNVRAMentry()
+##------------------------------------------------##
+## Modified by Martinski W. [2025-Sep-05]
+##------------------------------------------------##
+## ARG #1 "$line" has the following format:
+## "{MAC_address}|{IP_address}|{DNS_IP}|{Hostname}"
+## "$line" comes from exported NVRAM variable so
+## we'll check for possible duplicate entries.
+## If duplicates found, NVRAM entry is ignored.
+##--------------------------------------------------
+Validate_NVRAM_IPaddr_Reservation()
 {
-   if [ $# -eq 0 ] || [ -z "$1" ] ; then return 1 ; fi
+    if [ $# -eq 0 ] || [ -z "$1" ] || \
+       ! echo "$1" | grep -q "|"
+    then return 1
+    fi
+    local MACx_Addrs  dupInfoMsg=""  retCode=0
+    local IPv4_Addr4  IPv4_Addr3  theClientX  theClientY
 
-   retCode=0
-   dupInfoMsg=""
-   MACx_Addrs="$(echo "$1" | awk -F '|' '{print $1}')"
-   IPv4_Addrs="$(echo "$1" | awk -F '|' '{print $2}')"
-   theClientx="${MACx_Addrs},${IPv4_Addrs}"
+    MACx_Addrs="$(echo "$1" | awk -F '|' '{print $1}')"
+    IPv4_Addr4="$(echo "$1" | awk -F '|' '{print $2}')"
+    IPv4_Addr3="$(echo "$IPv4_Addr4" | cut -d'.' -f1-3)"
+    theClientX="${MACx_Addrs},${IPv4_Addr4}"
+    theClientY="${MACx_Addrs},${IPv4_Addr3}"
+    theClientZ="${MACaddr_RegEx},${IPv4_Addr4}"
 
-   if grep -qi "^${theClientx}" "$SCRIPT_CONF"
-   then
-       dupInfoMsg="Client entry [$theClientx] is already found"
-   elif grep -qi "^${MACx_Addrs}," "$SCRIPT_CONF"
-   then
-       dupInfoMsg="Client MAC address [$MACx_Addrs] is already found"
-   elif grep -qi ",${IPv4_Addrs}," "$SCRIPT_CONF"
-   then
-       dupInfoMsg="Client IP address [$IPv4_Addrs] is already assigned"
-   fi
-   if [ -n "$dupInfoMsg" ]
-   then
-       Print_Output true "$dupInfoMsg in $SCRIPT_CONF file" "$WARN"
-       Print_Output true "NVRAM entry will be skipped/ignored." "$WARN"
-       retCode=1
-   fi
-   return $retCode
+    if grep -qi "^${theClientX}," "$SCRIPT_CONF"
+    then
+        dupInfoMsg="Client IP address reservation [${REDct}${theClientX}${WARN}] is already assigned"
+    elif grep -qiE "^${theClientY}[.]${IPv4octet_RegEx}," "$SCRIPT_CONF"
+    then
+        dupInfoMsg="Client IP address reservation [${REDct}${theClientY}.*${WARN}] within the same subnet already assigned"
+    elif grep -qE "^${theClientZ}," "$SCRIPT_CONF"
+    then
+        dupInfoMsg="Client IP address reservation [${REDct}${IPv4_Addr4}${WARN}] has already been assigned to another client"
+    fi
+
+    if [ -n "$dupInfoMsg" ]
+    then
+        Print_Output true "$dupInfoMsg in $SCRIPT_NAME clients file" "$WARN" oneline
+        Print_Output true "The NVRAM entry will be skipped/ignored." "$WARN"
+        retCode=1
+    fi
+    return "$retCode"
 }
 
-##----------------------------------------##
-## Modified by Martinski W. [2024-Jun-27] ##
-##----------------------------------------##
-### nvram parsing code based on dhcpstaticlist.sh by @Xentrk ###
-Export_FW_DHCP_JFFS()
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+_CheckFor_NVRAM_DHCP_Assignments_3004_()
 {
-	printf "\n${BOLD}Do you want to export DHCP assignments and hostnames from NVRAM to %s DHCP client files?${CLEARct}\n" "$SCRIPT_NAME"
-	printf "%s will backup NVRAM/JFFS DHCP data as part of the export process.\n" "$SCRIPT_NAME"
-	printf "\n${BOLD}Enter answer (y/n):  ${CLEARct}"
-	read -r confirm
-	case "$confirm" in
-		y|Y)
-			:
-		;;
-		*)
-			Clear_Lock
-			return 1
-		;;
-	esac
+	if [ -s /jffs/nvram/dhcp_staticlist ] || \
+	   nvram show 2>/dev/null | grep -qE "^$NVRAM_3004_DHCPvar_RegExp"
+	then return 0
+	else return 1
+	fi
+}
 
-	if [ "$(nvram get dhcp_staticlist | wc -m)" -le 1 ]
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-06] ##
+##-------------------------------------##
+_CheckFor_NVRAM_DHCP_Assignments_3006_()
+{
+	if [ "$fwInstalledBaseVers" -ge 3006 ] && \
+	   nvram show 2>/dev/null | grep -qE "^$NVRAM_3006_DHCPvar_RegExp1"
+	then return 0
+	else return 1
+	fi
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+_CheckForSaved_NVRAM_DHCP_Assignments_3004_()
+{
+	if [ -f "${SCRIPT_DIR}/.nvram_dhcp_staticlist" ] || \
+	   [ -f "${SCRIPT_DIR}/.nvram_jffs_dhcp_staticlist" ]
+	then return 0
+	else return 1
+	fi
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+_Restore_NVRAM_DHCP_Assignments_3004_()
+{
+	if [ -f "${SCRIPT_DIR}/.nvram_jffs_dhcp_staticlist" ]
 	then
-		Print_Output true "DHCP static assignments not exported from NVRAM, no data found" "$PASS"
-		Clear_Lock
-		return 1
+		nvram set dhcp_staticlist="$(cat "${SCRIPT_DIR}/.nvram_jffs_dhcp_staticlist")"
+		doCommitNVRAM=true ; restoredOK=true
+	fi
+	if [ -f "${SCRIPT_DIR}/.nvram_dhcp_staticlist" ]
+	then
+		nvram set dhcp_staticlist="$(cat "${SCRIPT_DIR}/.nvram_dhcp_staticlist")"
+		doCommitNVRAM=true ; restoredOK=true
+	fi
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+_Export_NVRAM_DHCP_Assignments_3004_()
+{
+	if [ $# -eq 0 ] || [ -z "$1" ] || [ ! -f "$1" ]
+	then return 1
+	fi
+	local nvramKeyVal
+
+	if [ -s /jffs/nvram/dhcp_staticlist ]
+	then
+		cp -f /jffs/nvram/dhcp_staticlist "${SCRIPT_DIR}/.nvram_jffs_dhcp_staticlist"
+		sed 's/</\n/g;s/>/|/g;s/<//g' /jffs/nvram/dhcp_staticlist | sed '/^$/d' > "$1"
+		echo >> "$1"
 	fi
 
-	if [ "$(Firmware_Version_Number "$fwInstalledBranchVer")" -lt "$(Firmware_Version_Number "3004.386.4")" ]
+	nvramKeyVal="$(nvram get dhcp_staticlist)"
+	if [ -n "$nvramKeyVal" ]
+	then
+		echo "$nvramKeyVal" | sed 's/</\n/g;s/>/|/g;s/<//g' | sed '/^$/d' > "$1"
+		# Make sure key value has the initial angle bracket #
+		if ! echo "$nvramKeyVal" | grep -qE "^<.*"
+		then nvramKeyVal="<$nvramKeyVal"
+		fi
+		echo "$nvramKeyVal" > "${SCRIPT_DIR}/.nvram_dhcp_staticlist"
+		nvram unset dhcp_staticlist
+		doCommitNVRAM=true
+	fi
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-06] ##
+##-------------------------------------##
+_CheckForSaved_NVRAM_DHCP_Assignments_3006_()
+{
+	if [ "$fwInstalledBaseVers" -lt 3006 ]
+	then return 1
+	fi
+	local nvramSavedFiles  theSavedFile
+
+	nvramSavedFiles="$(ls -1 "${SCRIPT_DIR}"/.nvram_dhcp_dhcpres* 2>/dev/null)"
+	if [ "${#nvramSavedFiles}" -eq 0 ]
+	then return 1
+	else return 0
+	fi
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-06] ##
+##-------------------------------------##
+_Restore_NVRAM_DHCP_Assignments_3006_()
+{
+	if [ "$fwInstalledBaseVers" -lt 3006 ]
+	then return 1
+	fi
+	local nvramSavedFiles  theSavedFile  nvramKeyName
+
+	nvramSavedFiles="$(ls -1 "${SCRIPT_DIR}"/.nvram_dhcp_dhcpres* 2>/dev/null)"
+	if [ "${#nvramSavedFiles}" -eq 0 ]
+	then return 1
+	fi
+	for theSavedFile in $nvramSavedFiles
+	do
+		if echo "$theSavedFile" | grep -qE "^${SCRIPT_DIR}/.nvram_dhcp_dhcpres[1-9][0-9]?_rl$"
+		then
+			nvramKeyName="$(basename "$theSavedFile" | cut -d'_' -f3-)"
+			if [ -n "$nvramKeyName" ]
+			then
+				nvram set ${nvramKeyName}="$(cat "$theSavedFile")"
+				doCommitNVRAM=true ; restoredOK=true
+			fi
+		fi
+	done
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-06] ##
+##-------------------------------------##
+_Export_NVRAM_DHCP_Assignments_3006_()
+{
+	if [ "$fwInstalledBaseVers" -lt 3006 ] || \
+	   [ $# -eq 0 ] || [ -z "$1" ] || [ ! -f "$1" ]
+	then return 1
+	fi
+	local dhcpNVRAMvarKeyList  nvramVarKeyStr  nvramVarKey  nvramKeyVal
+
+	dhcpNVRAMvarKeyList="$(nvram show 2>/dev/null | grep -oE "^$NVRAM_3006_DHCPvar_RegExp0" | sort -u)"
+	if [ "${#dhcpNVRAMvarKeyList}" -eq 0 ]
+	then return 1
+	fi
+	for nvramVarKeyStr in $dhcpNVRAMvarKeyList
+	do
+		nvramVarKey="$(echo "$nvramVarKeyStr" | cut -d'=' -f1)"
+		nvramKeyVal="$(nvram get "$nvramVarKey")"
+		if [ -n "$nvramKeyVal" ]
+		then
+			echo "$nvramKeyVal" > "$SCRIPT_DIR/.nvram_dhcp_$nvramVarKey"
+			echo "$nvramKeyVal" | sed 's/</\n/g;s/>/|/g;s/<//g' | sed '/^$/d' >> "$1"
+			nvram unset "$nvramVarKey"
+			doCommitNVRAM=true
+		fi
+	done
+}
+
+##----------------------------------------------##
+## OLDER F/W < "3004.386.4" NO LONGER SUPPORTED
+## [3004.386.4 F/W was released on 2022-Jan-01]
+##----------------------------------------------##
+## Modified by Martinski W. [2025-Sep-05]
+##----------------------------------------------##
+_Export_DHCP_NVRAM_OLD_FW_Versions_()
+{
+	if false   ##[ "$(FirmwareVersionNum "3004.386.4")" ]##
 	then
 		if [ -f /jffs/nvram/dhcp_hostnames ]
 		then
 			if [ "$(wc -m < /jffs/nvram/dhcp_hostnames)" -le 1 ]
 			then
-				Print_Output true "DHCP hostnames not exported from NVRAM, no data found" "$PASS"
+				Print_Output true "DHCP hostnames NOT exported from NVRAM, no data found" "$PASS"
 				Clear_Lock
 				return 1
 			fi
-		elif [ "$(nvram get dhcp_hostnames | wc -m)" -le 1 ]; then
-			Print_Output true "DHCP hostnames not exported from NVRAM, no data found" "$PASS"
+		elif [ "$(nvram get dhcp_hostnames | wc -m)" -le 1 ]
+		then
+			Print_Output true "DHCP hostnames NOT exported from NVRAM, no data found" "$PASS"
 			Clear_Lock
 			return 1
 		fi
@@ -2243,193 +3283,947 @@ Export_FW_DHCP_JFFS()
 		fi
 		nvram get dhcp_hostnames > "$SCRIPT_DIR/.nvram_dhcp_hostnames"
 		nvram unset dhcp_hostnames
-	else
-		if [ -f /jffs/nvram/dhcp_staticlist ]; then
-			sed 's/</\n/g;s/>/|/g;s/<//g' /jffs/nvram/dhcp_staticlist | sed '/^$/d' > /tmp/yazdhcp.tmp
-		else
-			nvram get dhcp_staticlist | sed 's/</\n/g;s/>/|/g;s/<//g'| sed '/^$/d' > /tmp/yazdhcp.tmp
+	fi
+}
+
+##----------------------------------------##
+## Modified by Martinski W. [2025-Sep-05] ##
+##----------------------------------------##
+Export_FW_DHCP_NVRAM_JFFS()
+{
+	printf "\n${BOLD}Do you want to export DHCP IP address assignments and hostnames"
+	printf "\nfrom NVRAM to %s internal client files?${CLEARct}\n" "$SCRIPT_NAME"
+	printf "\n%s will make backups of the existing NVRAM/JFFS DHCP data" "$SCRIPT_NAME"
+	printf "\nas part of this export process.\n"
+	printf "\n${BOLD}Enter answer (y/n):${CLEARct}  "
+	read -r confirm
+	case "$confirm" in
+		y|Y)
+			:
+		;;
+		*)
+			Clear_Lock
+			return 1
+		;;
+	esac
+	echo
+
+	if ! _CheckFor_NVRAM_DHCP_Assignments_3004_ && \
+	   ! _CheckFor_NVRAM_DHCP_Assignments_3006_
+	then
+		Print_Output true "DHCP IP address assignments NOT exported from NVRAM. No NVRAM settings found." "$PASS"
+		Clear_Lock
+		return 1
+	fi
+
+	local doCommitNVRAM  retStatus=false
+	local yazdhcpExportFile="/tmp/yazdhcp_EXPORT.tmp"
+
+	doCommitNVRAM=false
+	touch "$yazdhcpExportFile"
+	if _CheckFor_NVRAM_DHCP_Assignments_3004_
+	then
+		_Export_NVRAM_DHCP_Assignments_3004_  "$yazdhcpExportFile"
+	fi
+	if _CheckFor_NVRAM_DHCP_Assignments_3006_
+	then
+		_Export_NVRAM_DHCP_Assignments_3006_  "$yazdhcpExportFile"
+	fi
+	"$doCommitNVRAM" && nvram commit
+
+	if [ ! -s "$SCRIPT_CONF" ]
+	then echo "MAC,IP,HOSTNAME,DNS" > "$SCRIPT_CONF"
+	fi
+	sort -t . -k 3,3n -k 4,4n "$yazdhcpExportFile" > /tmp/yazdhcp_SORTED.tmp
+
+	while IFS='' read -r line || [ -n "$line" ]
+	do
+		if ! Validate_NVRAM_IPaddr_Reservation "$line"
+		then continue
 		fi
+		echo "$line" | awk 'FS="|" { print ""$1","$2","$4","$3""; }' >> "$SCRIPT_CONF"
+	done < /tmp/yazdhcp_SORTED.tmp
 
-		if [ ! -f "$SCRIPT_CONF" ] || [ ! -s "$SCRIPT_CONF" ]
-		then echo "MAC,IP,HOSTNAME,DNS" > "$SCRIPT_CONF" ; fi
-		sort -t . -k 3,3n -k 4,4n /tmp/yazdhcp.tmp > /tmp/yazdhcp_sorted.tmp
-
-		while IFS='' read -r line || [ -n "$line" ]
-		do
-			if ! ValidateNVRAMentry "$line" ; then continue ; fi
-			echo "$line" | awk 'FS="|" { print ""$1","$2","$4","$3""; }' >> "$SCRIPT_CONF"
-		done < /tmp/yazdhcp_sorted.tmp
-
-		rm -f /tmp/yazdhcp*.tmp
+	if [ -s "$yazdhcpExportFile" ]
+	then
+		retStatus=true
+		Print_Output true "DHCP settings were successfully exported from NVRAM" "$PASS"
 	fi
+	rm -f "$yazdhcpExportFile" /tmp/yazdhcp_SORTED.tmp
 
-	if [ -f /jffs/nvram/dhcp_staticlist ]; then
-		cp -f /jffs/nvram/dhcp_staticlist "$SCRIPT_DIR/.nvram_jffs_dhcp_staticlist"
-	fi
-	theKeyVal="$(nvram get dhcp_staticlist)"
-	if ! echo "$theKeyVal" | grep -qE "^<.*"
-	then theKeyVal="<$theKeyVal" ; fi
-	echo "$theKeyVal" > "$SCRIPT_DIR/.nvram_dhcp_staticlist"
-	nvram unset dhcp_staticlist
-	nvram commit
+	"$retStatus" && _Check_ActiveGuestNetwork_SubnetInfo_
 
-	Print_Output true "DHCP information successfully exported from NVRAM" "$PASS"
-
-	if ProcessDHCPClients true
+	if ! Process_DHCP_Clients && "$retStatus"
 	then
 		Print_Output true "Restarting dnsmasq for exported DHCP settings to take effect." "$PASS"
 		service restart_dnsmasq >/dev/null 2>&1
 	fi
+
 	Clear_Lock
+	"$retStatus" && return 0 || return 1
 }
-##################################################################
 
 ##----------------------------------------##
-## Modified by Martinski W. [2024-Feb-26] ##
+## Modified by Martinski W. [2025-Sep-05] ##
 ##----------------------------------------##
-ProcessDHCPClients()
+Update_Hostnames_MainLAN()
 {
-    local retCode=1
-    if [ $# -gt 0 ] && { [ "$1" = "true" ] || [ "$1" = "false" ] ; }
-    then RESTART_DNSMASQ="$1"
-    else RESTART_DNSMASQ=false
-    fi
+	local theMACaddr  theIPaddr4  theHostName  theDNSaddr  theIPaddr3
+	local LAN_IPaddr3="$(echo "$mainLAN_IPaddr" | cut -d'.' -f1-3)"
 
-    Update_Hostnames
-    Update_Staticlist
-    Update_Optionslist
+	while IFS=',' read -r theMACaddr theIPaddr4 theHostName theDNSaddr
+	do
+		if [ "$theMACaddr" = "MAC" ] || \
+             [ -z "$theHostName" ] || [ -z "$theIPaddr4" ]
+		then continue
+		fi
+		theIPaddr3="$(echo "$theIPaddr4" | cut -d'.' -f1-3)"
+		if [ "$theIPaddr3" = "$LAN_IPaddr3" ]
+		then
+			echo "$theIPaddr4 $theHostName" >> "$hostNamesFilePATH"
+		fi
+	done < "$SCRIPT_CONF"
+}
 
-    if "$RESTART_DNSMASQ"
-    then
-        retCode=0
-        Auto_DNSMASQ create false 2>/dev/null
-    fi
-    return "$retCode"
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+Update_Hostnames_GuestNet()
+{
+	local gnExistingMD5  gnUpdatedMD5  theIPaddr3
+	local gnInfoStr  gnListOfIFaces  gnIFaceVarStr
+	local gnIFaceName  gnStartIPaddr4  gnStartIPaddr3
+	local theMACaddr  theIPaddr4  theHostName  theDNSaddr
+	local hostNamesFileGNET  hostNamesFileBKUP  gnIFaceDelEntry
+
+	gnInfoStr="$(_Get_GuestNetwork_SubnetInfo_)"
+	if [ "${#gnInfoStr}" -eq 0 ]
+	then return 1
+	fi
+	gnListOfIFaces="$(echo "$gnInfoStr" | cut -d'=' -f1 | cut -d'_' -f2)"
+	if [ -z "$gnListOfIFaces" ]
+	then return 1
+	fi
+
+	if ! "$(_AllowGuestNetwork_IP_Reservations_ check)"
+	then gnIFaceDelEntry=true
+	else gnIFaceDelEntry=false
+	fi
+
+	for gnIFaceName in $gnListOfIFaces
+	do
+		gnExistingMD5=""  gnUpdatedMD5=""
+		hostNamesFileGNET="${hostNamesFilePATH}_${gnIFaceName}"
+		hostNamesFileBKUP="${hostNamesFileGNET}.BKUP"
+
+		if "$gnIFaceDelEntry"
+		then
+			if [ -s "$hostNamesFileGNET" ]
+			then
+				Print_Output true "DHCP hostname list for Guest Network [$gnIFaceName] was removed" "$WARN" oneline
+				if [ "$fwInstalledBaseVers" -ge 3006 ]
+				then RESTART_DNSMASQ=true
+				fi
+			fi
+			rm -f "$hostNamesFileGNET" "$hostNamesFileBKUP"
+			continue
+		fi
+		if [ -s "$hostNamesFileGNET" ]
+		then
+			gnExistingMD5="$(md5sum "$hostNamesFileGNET" | awk '{print $1}')"
+			mv -f "$hostNamesFileGNET" "$hostNamesFileBKUP"
+		fi
+		printf "" > "$hostNamesFileGNET"
+
+		gnIFaceVarStr="GNIFACE_${gnIFaceName}="
+		gnStartIPaddr4="$(echo "$gnInfoStr" | grep -E "^${gnIFaceVarStr}.*" | cut -d'=' -f2 | cut -d',' -f1)"
+		gnStartIPaddr3="$(echo "$gnStartIPaddr4" | cut -d'.' -f1-3)"
+
+		while IFS=',' read -r theMACaddr theIPaddr4 theHostName theDNSaddr
+		do
+			if [ "$theMACaddr" = "MAC" ] || \
+			   [ -z "$theHostName" ] || [ -z "$theIPaddr4" ]
+			then continue
+			fi
+			theIPaddr3="$(echo "$theIPaddr4" | cut -d'.' -f1-3)"
+			if [ "$theIPaddr3" = "$gnStartIPaddr3" ]
+			then
+				echo "$theIPaddr4 $theHostName" >> "$hostNamesFileGNET"
+			fi
+		done < "$SCRIPT_CONF"
+
+		if [ -s "$hostNamesFileGNET" ]
+		then
+			gnUpdatedMD5="$(md5sum "$hostNamesFileGNET" | awk '{print $1}')"
+		fi
+		if [ -n "$gnUpdatedMD5" ] && [ "$gnExistingMD5" != "$gnUpdatedMD5" ]
+		then
+			Print_Output true "DHCP hostname list for Guest Network [$gnIFaceName] updated successfully" "$PASS" oneline
+			if [ "$fwInstalledBaseVers" -ge 3006 ]
+			then RESTART_DNSMASQ=true
+			fi
+		elif [ -z "$gnUpdatedMD5" ]
+		then
+			if [ -s "$hostNamesFileBKUP" ]
+			then
+				Print_Output true "DHCP hostname list for Guest Network [$gnIFaceName] was removed." "$WARN" oneline
+				if [ "$fwInstalledBaseVers" -ge 3006 ]
+				then RESTART_DNSMASQ=true
+				fi
+			fi
+		else
+			if [ -s "$hostNamesFileBKUP" ]
+			then cp -fp "$hostNamesFileBKUP" "$hostNamesFileGNET"
+			fi
+			Print_Output true "DHCP hostname list for Guest Network [$gnIFaceName] remains unchanged" "$PASS" oneline
+		fi
+		if [ "$fwInstalledBaseVers" -lt 3006 ] && [ -s "$hostNamesFileGNET" ]
+		then
+			cat "$hostNamesFileGNET" >> "$hostNamesFilePATH"
+		fi
+		"$delBkupCopy" && rm -f "$hostNamesFileBKUP"
+	done
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2023-Mar-14] ##
+## Modified by Martinski W. [2025-Sep-05] ##
+##----------------------------------------##
+Update_StaticList_MainLAN()
+{
+	local theMACaddr  theIPaddr4  theHostName  theDNSaddr
+	local hostNameEntry  dhcpNetwkTagID  dhcpNetTagStr  theIPaddr3
+	local LAN_IPaddr3="$(echo "$mainLAN_IPaddr" | cut -d'.' -f1-3)"
+
+	_Get_DHCP_NetworkTagStr_ "$mainLAN_IPaddr" MainLAN
+
+	while IFS=',' read -r theMACaddr theIPaddr4 theHostName theDNSaddr
+	do
+		if [ "$theMACaddr" = "MAC" ] || \
+		   [ -z "$theMACaddr" ] || [ -z "$theIPaddr4" ]
+		then continue
+		fi
+		if [ -z "$theHostName" ]
+		then hostNameEntry=""
+		else hostNameEntry=",$theHostName"
+		fi
+		if [ -z "$dhcpNetwkTagID" ] || [ "$dhcpNetwkTagID" = "NONE" ]
+		then dhcpNetTagStr=""
+		else dhcpNetTagStr="set:${dhcpNetwkTagID},"
+		fi
+
+		theIPaddr3="$(echo "$theIPaddr4" | cut -d'.' -f1-3)"
+		if [ "$theIPaddr3" = "$LAN_IPaddr3" ]
+		then
+			{
+			    echo "${dhcpNetTagStr}${theMACaddr},set:${theMACaddr},${theIPaddr4}${hostNameEntry}" 
+			} >> "$staticListFilePATH"
+		fi
+	done < "$SCRIPT_CONF"
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+Update_StaticList_GuestNet()
+{
+	local gnExistingMD5  gnUpdatedMD5  theIPaddr3
+	local gnInfoStr  gnListOfIFaces  gnIFaceVarStr
+	local gnIFaceName  gnStartIPaddr4  gnStartIPaddr3
+	local theMACaddr  theIPaddr4  theHostName  theDNSaddr
+	local hostNameEntry  dhcpNetwkTagID  dhcpNetTagStr  retCode
+	local staticListFileGNET  staticListFileBKUP  gnIFaceDelEntry
+
+	gnInfoStr="$(_Get_GuestNetwork_SubnetInfo_)"
+	if [ "${#gnInfoStr}" -eq 0 ]
+	then return 1
+	fi
+	gnListOfIFaces="$(echo "$gnInfoStr" | cut -d'=' -f1 | cut -d'_' -f2)"
+	if [ -z "$gnListOfIFaces" ]
+	then return 1
+	fi
+
+	if ! "$(_AllowGuestNetwork_IP_Reservations_ check)"
+	then gnIFaceDelEntry=true
+	else gnIFaceDelEntry=false
+	fi
+	retCode=1
+
+	for gnIFaceName in $gnListOfIFaces
+	do
+		gnExistingMD5=""  gnUpdatedMD5=""
+		staticListFileGNET="${staticListFilePATH}_${gnIFaceName}"
+		staticListFileBKUP="${staticListFileGNET}.BKUP"
+
+		if "$gnIFaceDelEntry"
+		then
+			if [ -s "$staticListFileGNET" ]
+			then
+				retCode=0
+				Print_Output true "DHCP IP address reservation list for Guest Network [$gnIFaceName] was removed" "$WARN" oneline
+				if [ "$fwInstalledBaseVers" -ge 3006 ]
+				then RESTART_DNSMASQ=true
+				fi
+			fi
+			rm -f "$staticListFileGNET" "$staticListFileBKUP"
+			continue
+		fi
+		if [ -s "$staticListFileGNET" ]
+		then
+			gnExistingMD5="$(md5sum "$staticListFileGNET" | awk '{print $1}')"
+			mv -f "$staticListFileGNET" "$staticListFileBKUP"
+		fi
+		printf "" > "$staticListFileGNET"
+
+		gnIFaceVarStr="GNIFACE_${gnIFaceName}="
+		gnStartIPaddr4="$(echo "$gnInfoStr" | grep -E "^${gnIFaceVarStr}.*" | cut -d'=' -f2 | cut -d',' -f1)"
+		gnStartIPaddr3="$(echo "$gnStartIPaddr4" | cut -d'.' -f1-3)"
+		dhcpNetwkTagID="$(echo "$gnInfoStr" | grep -E "^${gnIFaceVarStr}.*" | cut -d'=' -f2 | cut -d',' -f4)"
+
+		while IFS=',' read -r theMACaddr theIPaddr4 theHostName theDNSaddr
+		do
+			if [ "$theMACaddr" = "MAC" ] || \
+			   [ -z "$theMACaddr" ] || [ -z "$theIPaddr4" ]
+			then continue
+			fi
+			if [ -z "$theHostName" ]
+			then hostNameEntry=""
+			else hostNameEntry=",$theHostName"
+			fi
+			if [ -z "$dhcpNetwkTagID" ] || [ "$dhcpNetwkTagID" = "NONE" ]
+			then dhcpNetTagStr=""
+			else dhcpNetTagStr="set:${dhcpNetwkTagID},"
+			fi
+
+			theIPaddr3="$(echo "$theIPaddr4" | cut -d'.' -f1-3)"
+			if [ "$theIPaddr3" = "$gnStartIPaddr3" ]
+			then
+				{
+				    echo "${dhcpNetTagStr}${theMACaddr},set:${theMACaddr},${theIPaddr4}${hostNameEntry}" 
+				} >> "$staticListFileGNET"
+			fi
+		done < "$SCRIPT_CONF"
+
+		if [ "$(_GetFileSizeBytes_ "$staticListFileGNET")" -ge 3 ]
+		then
+			gnUpdatedMD5="$(md5sum "$staticListFileGNET" | awk '{print $1}')"
+		fi
+		if [ -n "$gnUpdatedMD5" ] && [ "$gnExistingMD5" != "$gnUpdatedMD5" ]
+		then
+			retCode=0
+			Print_Output true "DHCP IP address reservation list for Guest Network [$gnIFaceName] updated successfully" "$PASS" oneline
+			if [ "$fwInstalledBaseVers" -ge 3006 ]
+			then RESTART_DNSMASQ=true
+			fi
+		elif [ -z "$gnUpdatedMD5" ]
+		then
+			if [ -s "$staticListFileBKUP" ]
+			then
+				retCode=0
+				Print_Output true "DHCP IP address reservation list for Guest Network [$gnIFaceName] was removed." "$WARN" oneline
+				if [ "$fwInstalledBaseVers" -ge 3006 ]
+				then RESTART_DNSMASQ=true
+				fi
+			fi
+		else
+			if [ -s "$staticListFileBKUP" ]
+			then cp -fp "$staticListFileBKUP" "$staticListFileGNET"
+			fi
+			Print_Output true "DHCP IP address reservation list for Guest Network [$gnIFaceName] remains unchanged" "$PASS" oneline
+		fi
+		if [ "$fwInstalledBaseVers" -lt 3006 ] && [ -s "$staticListFileGNET" ]
+		then
+			cat "$staticListFileGNET" >> "$staticListFilePATH"
+		fi
+		"$delBkupCopy" && rm -f "$staticListFileBKUP"
+		if [ "$(_GetFileSizeBytes_ "$staticListFileGNET")" -lt 3 ]
+		then rm -f "$staticListFileGNET"
+		fi
+	done
+
+	CleanUp_StaticList_GuestNet
+	return "$retCode"
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-13] ##
+##-------------------------------------##
+CleanUp_StaticList_GuestNet()
+{
+	local gnInfoStr  gnListOfIFaces  gnIFaceName
+	local staticListRegExp  staticListFPath
+
+	gnInfoStr="$(_Get_GuestNetwork_SubnetInfo_)"
+	if [ "${#gnInfoStr}" -eq 0 ]
+	then return 1
+	fi
+	gnListOfIFaces="$(echo "$gnInfoStr" | cut -d'=' -f1 | cut -d'_' -f2)"
+	if [ -z "$gnListOfIFaces" ]
+	then return 1
+	fi
+
+	staticListRegExp="${SCRIPT_DIR}/.staticlist_*"
+	for staticListFPath in $(ls -1 $staticListRegExp 2>/dev/null)
+	do
+		gnIFaceName="$(basename "$staticListFPath" | cut -d'_' -f2)"
+		if ! echo "$gnIFaceName" | grep -qE "^${guestNetIFaces0RegExp}$" || \
+		   echo "$gnListOfIFaces" | grep -qw "$gnIFaceName"
+		then continue
+		fi
+		rm -f "$staticListFPath"
+	done
+}
+
+##----------------------------------------##
+## Modified by Martinski W. [2025-Sep-05] ##
+##----------------------------------------##
+Update_OptionsList_MainLAN()
+{
+	local theMACaddr  theIPaddr4  theHostName  theDNSaddr
+	local dhcpNetwkTagID  dhcpNetTagStr  theIPaddr3
+	local LAN_IPaddr3="$(echo "$mainLAN_IPaddr" | cut -d'.' -f1-3)"
+
+	_Get_DHCP_NetworkTagStr_ "$mainLAN_IPaddr" MainLAN
+
+	while IFS=',' read -r theMACaddr theIPaddr4 theHostName theDNSaddr
+	do
+		if [ "$theMACaddr" = "MAC" ] || \
+		   [ -z "$theDNSaddr" ] || [ -z "$theIPaddr4" ]
+		then continue
+		fi
+		if [ -z "$dhcpNetwkTagID" ] || [ "$dhcpNetwkTagID" = "NONE" ]
+		then dhcpNetTagStr=""
+		else dhcpNetTagStr="tag:${dhcpNetwkTagID},"
+		fi
+
+		theIPaddr3="$(echo "$theIPaddr4" | cut -d'.' -f1-3)"
+		if [ "$theIPaddr3" = "$LAN_IPaddr3" ]
+		then
+			{
+			    echo "${dhcpNetTagStr}tag:${theMACaddr},6,$theDNSaddr" 
+			} >> "$optionsListFilePATH"
+		fi
+	done < "$SCRIPT_CONF"
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+Update_OptionsList_GuestNet()
+{
+	local gnExistingMD5  gnUpdatedMD5  theIPaddr3
+	local gnInfoStr  gnListOfIFaces  gnIFaceVarStr
+	local gnIFaceName  gnStartIPaddr4  gnStartIPaddr3
+	local theMACaddr  theIPaddr4  theHostName  theDNSaddr
+	local dhcpNetwkTagID  dhcpNetTagStr  gnIFaceDelEntry
+	local optionsListFileGNET  optionsListFileBKUP  retCode
+
+	gnInfoStr="$(_Get_GuestNetwork_SubnetInfo_)"
+	if [ "${#gnInfoStr}" -eq 0 ]
+	then return 1
+	fi
+	gnListOfIFaces="$(echo "$gnInfoStr" | cut -d'=' -f1 | cut -d'_' -f2)"
+	if [ -z "$gnListOfIFaces" ]
+	then return 1
+	fi
+
+	if ! "$(_AllowGuestNetwork_IP_Reservations_ check)"
+	then gnIFaceDelEntry=true
+	else gnIFaceDelEntry=false
+	fi
+	retCode=1
+
+	for gnIFaceName in $gnListOfIFaces
+	do
+		gnExistingMD5=""  gnUpdatedMD5=""
+		optionsListFileGNET="${optionsListFilePATH}_${gnIFaceName}"
+		optionsListFileBKUP="${optionsListFileGNET}.BKUP"
+
+		if "$gnIFaceDelEntry"
+		then
+			if [ -s "$optionsListFileGNET" ]
+			then
+				retCode=0
+				Print_Output true "DHCP options list for Guest Network [$gnIFaceName] was removed" "$WARN" oneline
+				if [ "$fwInstalledBaseVers" -ge 3006 ]
+				then RESTART_DNSMASQ=true
+				fi
+			fi
+			rm -f "$optionsListFileGNET" "$optionsListFileBKUP"
+			continue
+		fi
+		if [ -s "$optionsListFileGNET" ]
+		then
+			gnExistingMD5="$(md5sum "$optionsListFileGNET" | awk '{print $1}')"
+			mv -f "$optionsListFileGNET" "$optionsListFileBKUP"
+		fi
+		printf "" > "$optionsListFileGNET"
+
+		gnIFaceVarStr="GNIFACE_${gnIFaceName}="
+		gnStartIPaddr4="$(echo "$gnInfoStr" | grep -E "^${gnIFaceVarStr}.*" | cut -d'=' -f2 | cut -d',' -f1)"
+		gnStartIPaddr3="$(echo "$gnStartIPaddr4" | cut -d'.' -f1-3)"
+		dhcpNetwkTagID="$(echo "$gnInfoStr" | grep -E "^${gnIFaceVarStr}.*" | cut -d'=' -f2 | cut -d',' -f4)"
+
+		while IFS=',' read -r theMACaddr theIPaddr4 theHostName theDNSaddr
+		do
+			if [ "$theMACaddr" = "MAC" ] || \
+			   [ -z "$theDNSaddr" ] || [ -z "$theIPaddr4" ]
+			then continue
+			fi
+			if [ -z "$dhcpNetwkTagID" ] || [ "$dhcpNetwkTagID" = "NONE" ]
+			then dhcpNetTagStr=""
+			else dhcpNetTagStr="tag:${dhcpNetwkTagID},"
+			fi
+
+			theIPaddr3="$(echo "$theIPaddr4" | cut -d'.' -f1-3)"
+			if [ "$theIPaddr3" = "$gnStartIPaddr3" ]
+			then
+				{
+				    echo "${dhcpNetTagStr}tag:${theMACaddr},6,$theDNSaddr" 
+				} >> "$optionsListFileGNET"
+			fi
+		done < "$SCRIPT_CONF"
+
+		if [ "$(_GetFileSizeBytes_ "$optionsListFileGNET")" -ge 3 ]
+		then
+			gnUpdatedMD5="$(md5sum "$optionsListFileGNET" | awk '{print $1}')"
+		fi
+		if [ -n "$gnUpdatedMD5" ] && [ "$gnExistingMD5" != "$gnUpdatedMD5" ]
+		then
+			retCode=0
+			Print_Output true "DHCP options list for Guest Network [$gnIFaceName] updated successfully" "$PASS" oneline
+			if [ "$fwInstalledBaseVers" -ge 3006 ]
+			then RESTART_DNSMASQ=true
+			fi
+		elif [ -z "$gnUpdatedMD5" ]
+		then
+			if [ -s "$optionsListFileBKUP" ]
+			then
+				retCode=0
+				Print_Output true "DHCP options list for Guest Network [$gnIFaceName] was removed." "$WARN" oneline
+				if [ "$fwInstalledBaseVers" -ge 3006 ]
+				then RESTART_DNSMASQ=true
+				fi
+			fi
+		else
+			if [ -s "$optionsListFileBKUP" ]
+			then cp -fp "$optionsListFileBKUP" "$optionsListFileGNET"
+			fi
+			Print_Output true "DHCP options list for Guest Network [$gnIFaceName] remains unchanged" "$PASS" oneline
+		fi
+		if [ "$fwInstalledBaseVers" -lt 3006 ] && [ -s "$optionsListFileGNET" ]
+		then
+			cat "$optionsListFileGNET" >> "$optionsListFilePATH"
+		fi
+		"$delBkupCopy" && rm -f "$optionsListFileBKUP"
+		if [ "$(_GetFileSizeBytes_ "$optionsListFileGNET")" -lt 3 ]
+		then rm -f "$optionsListFileGNET"
+		fi
+	done
+
+	CleanUp_OptionsList_GuestNet
+	return "$retCode"
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-13] ##
+##-------------------------------------##
+CleanUp_OptionsList_GuestNet()
+{
+	local gnInfoStr  gnListOfIFaces  gnIFaceName
+	local optionsListRegExp  optionsListFPath
+
+	gnInfoStr="$(_Get_GuestNetwork_SubnetInfo_)"
+	if [ "${#gnInfoStr}" -eq 0 ]
+	then return 1
+	fi
+	gnListOfIFaces="$(echo "$gnInfoStr" | cut -d'=' -f1 | cut -d'_' -f2)"
+	if [ -z "$gnListOfIFaces" ]
+	then return 1
+	fi
+
+	optionsListRegExp="${SCRIPT_DIR}/.optionslist_*"
+	for optionsListFPath in $(ls -1 $optionsListRegExp 2>/dev/null)
+	do
+		gnIFaceName="$(basename "$optionsListFPath" | cut -d'_' -f2)"
+		if ! echo "$gnIFaceName" | grep -qE "^${guestNetIFaces0RegExp}$" || \
+		   echo "$gnListOfIFaces" | grep -qw "$gnIFaceName"
+		then continue
+		fi
+		rm -f "$optionsListFPath"
+	done
+}
+
+##----------------------------------------##
+## Modified by Martinski W. [2025-Sep-05] ##
 ##----------------------------------------##
 Update_Hostnames()
 {
-	existingmd5=""
-	if [ -f "$SCRIPT_DIR/.hostnames" ]; then
-		existingmd5="$(md5sum "$SCRIPT_DIR/.hostnames" | awk '{print $1}')"
-	fi
-	tail -n +2 "$SCRIPT_CONF" | awk -F',' '$3 != "" { print ""$2" "$3""; }' > "$SCRIPT_DIR/.hostnames"
+	local lanExistingMD5=""  lanUpdatedMD5=""  msgTagStr=""
+	local hostNamesFilePATH="$SCRIPT_DIR/.hostnames"
+	local hostNamesFileORIG="${hostNamesFilePATH}.BKUP"
 
-	updatedmd5="$(md5sum "$SCRIPT_DIR/.hostnames" | awk '{print $1}')"
-	if [ "$existingmd5" != "$updatedmd5" ]; then
-		Print_Output true "DHCP hostname list updated successfully" "$PASS"
-		RESTART_DNSMASQ=true
-	else
-		Print_Output true "DHCP hostname list unchanged" "$WARN"
+	#-----------------------------------------------------------------
+	# The Hostnames file is no longer needed because the information 
+     # is now included/embedded in the "staticlist" file.
+	#-----------------------------------------------------------------
+	if ! "$addnDHCP_HostNames"
+	then
+		rm -f "$hostNamesFilePATH" "$hostNamesFileORIG"
+		return 0
 	fi
+
+	if [ -s "$hostNamesFilePATH" ]
+	then
+		lanExistingMD5="$(md5sum "$hostNamesFilePATH" | awk '{print $1}')"
+		mv -f "$hostNamesFilePATH" "$hostNamesFileORIG"
+	fi
+	printf "" > "$hostNamesFilePATH"
+
+	Update_Hostnames_MainLAN
+	##OFF## Update_Hostnames_GuestNet ##OFF##
+
+	if [ -s "$hostNamesFilePATH" ]
+	then
+		lanUpdatedMD5="$(md5sum "$hostNamesFilePATH" | awk '{print $1}')"
+	fi
+
+	if "$(_AllowGuestNetwork_IP_Reservations_ check)"
+	then msgTagStr="for main LAN [$mainLAN_IFname] "
+	fi
+
+	if [ -n "$lanUpdatedMD5" ] && [ "$lanExistingMD5" != "$lanUpdatedMD5" ]
+	then
+		Print_Output true "DHCP hostname list ${msgTagStr}updated successfully" "$PASS" oneline
+		RESTART_DNSMASQ=true
+	elif [ -n "$lanUpdatedMD5" ]
+	then
+		if [ -s "$hostNamesFileORIG" ]
+		then cp -fp "$hostNamesFileORIG" "$hostNamesFilePATH"
+		fi
+		"$verboseMode" && \
+		Print_Output true "DHCP hostname list ${msgTagStr}remains unchanged" "$PASS" oneline
+	fi
+	"$delBkupCopy" && rm -f "$hostNamesFileORIG"
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2023-Mar-14] ##
+## Modified by Martinski W. [2025-Sep-05] ##
 ##----------------------------------------##
-Update_Staticlist()
+Update_StaticList()
 {
-	existingmd5=""
-	if [ -f "$SCRIPT_DIR/.staticlist" ]; then
-		existingmd5="$(md5sum "$SCRIPT_DIR/.staticlist" | awk '{print $1}')"
+	local lanExistingMD5=""  lanUpdatedMD5=""  msgTagStr=""
+	local staticListFilePATH="$SCRIPT_DIR/.staticlist"
+	local staticListFileBKUP="${staticListFilePATH}.BKUP"
+
+	if [ -s "$staticListFilePATH" ]
+	then
+		lanExistingMD5="$(md5sum "$staticListFilePATH" | awk '{print $1}')"
+		mv -f "$staticListFilePATH" "$staticListFileBKUP"
 	fi
-	tail -n +2 "$SCRIPT_CONF" | awk -F',' '{ print ""$1",set:"$1","$2""; }' > "$SCRIPT_DIR/.staticlist"
-	updatedmd5="$(md5sum "$SCRIPT_DIR/.staticlist" | awk '{print $1}')"
-	if [ "$existingmd5" != "$updatedmd5" ]; then
-		Print_Output true "DHCP static assignment list updated successfully" "$PASS"
+	printf "" > "$staticListFilePATH"
+
+	Update_StaticList_MainLAN
+	Update_StaticList_GuestNet
+	if [ $? -eq 0 ] || "$(_AllowGuestNetwork_IP_Reservations_ check)"
+	then msgTagStr="for main LAN [$mainLAN_IFname] "
+	fi
+
+	if [ "$(_GetFileSizeBytes_ "$staticListFilePATH")" -ge 3 ]
+	then
+		lanUpdatedMD5="$(md5sum "$staticListFilePATH" | awk '{print $1}')"
+	fi
+	if [ -n "$lanUpdatedMD5" ] && [ "$lanExistingMD5" != "$lanUpdatedMD5" ]
+	then
+		Print_Output true "DHCP IP address reservation list ${msgTagStr}updated successfully" "$PASS" oneline
 		RESTART_DNSMASQ=true
-	else
-		Print_Output true "DHCP static assignment list unchanged" "$WARN"
+	elif [ -n "$lanUpdatedMD5" ]  #NO Change#
+	then
+		if [ "$(_GetFileSizeBytes_ "$staticListFileBKUP")" -ge 3 ]
+		then cp -fp "$staticListFileBKUP" "$staticListFilePATH"
+		fi
+		"$verboseMode" && \
+		Print_Output true "DHCP IP address reservation list ${msgTagStr}remains unchanged" "$PASS" oneline
+	fi
+	"$delBkupCopy" && rm -f "$staticListFileBKUP"
+	if [ "$(_GetFileSizeBytes_ "$staticListFilePATH")" -lt 3 ]
+	then rm -f "$staticListFilePATH"
 	fi
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2023-Mar-14] ##
+## Modified by Martinski W. [2025-Sep-05] ##
 ##----------------------------------------##
-Update_Optionslist()
+Update_OptionsList()
 {
-	existingmd5=""
-	if [ -f "$SCRIPT_DIR/.optionslist" ]; then
-		existingmd5="$(md5sum "$SCRIPT_DIR/.optionslist" | awk '{print $1}')"
+	local lanExistingMD5=""  lanUpdatedMD5=""  msgTagStr=""
+	local optionsListFilePATH="$SCRIPT_DIR/.optionslist"
+	local optionsListFileBKUP="${optionsListFilePATH}.BKUP"
+
+	if [ -s "$optionsListFilePATH" ]
+	then
+		lanExistingMD5="$(md5sum "$optionsListFilePATH" | awk '{print $1}')"
+		mv -f "$optionsListFilePATH" "$optionsListFileBKUP"
 	fi
-	tail -n +2 "$SCRIPT_CONF" | awk -F',' '$4 != "" { print "tag:"$1",6,"$4""; }' > "$SCRIPT_DIR/.optionslist"
-	updatedmd5="$(md5sum "$SCRIPT_DIR/.optionslist" | awk '{print $1}')"
-	if [ "$existingmd5" != "$updatedmd5" ]; then
-		Print_Output true "DHCP options list updated successfully" "$PASS"
+	printf "" > "$optionsListFilePATH"
+
+	Update_OptionsList_MainLAN
+	Update_OptionsList_GuestNet
+	if [ $? -eq 0 ] || "$(_AllowGuestNetwork_IP_Reservations_ check)"
+	then msgTagStr="for main LAN [$mainLAN_IFname] "
+	fi
+
+	if [ -s "$optionsListFilePATH" ]
+	then
+		lanUpdatedMD5="$(md5sum "$optionsListFilePATH" | awk '{print $1}')"
+	fi
+	if [ -n "$lanUpdatedMD5" ] && [ "$lanExistingMD5" != "$lanUpdatedMD5" ]
+	then
+		Print_Output true "DHCP options list ${msgTagStr}updated successfully" "$PASS" oneline
 		RESTART_DNSMASQ=true
-	else
-		Print_Output true "DHCP options list unchanged" "$WARN"
+	elif [ -n "$lanUpdatedMD5" ]  #NO Change#
+	then
+		if [ "$(_GetFileSizeBytes_ "$optionsListFileBKUP")" -ge 3 ]
+		then cp -fp "$optionsListFileBKUP" "$optionsListFilePATH"
+		fi
+		"$verboseMode" && \
+		Print_Output true "DHCP options list ${msgTagStr}remains unchanged" "$PASS" oneline
+	fi
+	"$delBkupCopy" && rm -f "$optionsListFileBKUP"
+	if [ "$(_GetFileSizeBytes_ "$optionsListFilePATH")" -lt 3 ]
+	then rm -f "$optionsListFilePATH"
 	fi
 }
 
+##----------------------------------------##
+## Modified by Martinski W. [2025-Sep-05] ##
+##----------------------------------------##
+Process_DHCP_Clients()
+{
+	local retCode=1  delBkupCopy=true  verboseMode
+	if [ $# -gt 0 ] && { [ "$1" = "true" ] || [ "$1" = "false" ] ; }
+	then RESTART_DNSMASQ="$1"
+	else RESTART_DNSMASQ=false
+	fi
+
+	if [ ! -s "$SCRIPT_CONF" ] || \
+	   ! grep -qv "MAC,IP,HOSTNAME,DNS" "$SCRIPT_CONF"
+	then
+		Print_Output true "No DHCP client IP address assignments were found." "$WARN"
+		return 1
+	fi
+
+	verboseMode="${setVerboseMode:=true}"
+	Update_Hostnames
+	Update_StaticList
+	Update_OptionsList
+
+	if "$RESTART_DNSMASQ"
+	then
+		retCode=0
+		Auto_DNSMASQ create true
+	fi
+	return "$retCode"
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+_CenterTextStr_()
+{
+    if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ] || \
+       ! echo "$2" | grep -qE "^[1-9][0-9]+$"
+    then echo ; return 1
+    fi
+    local stringLen="${#1}"
+    local space1Len="$((($2 - stringLen)/2))"
+    local space2Len="$space1Len"
+    local totalLen="$((space1Len + stringLen + space2Len))"
+
+    if [ "$totalLen" -lt "$2" ]
+    then space2Len="$((space2Len + 1))"
+    elif [ "$totalLen" -gt "$2" ]
+    then space1Len="$((space1Len - 1))"
+    fi
+    if [ "$space1Len" -gt 0 ] && [ "$space2Len" -gt 0 ]
+    then printf "%*s%s%*s" "$space1Len" '' "$1" "$space2Len" ''
+    else printf "%s" "$1"
+    fi
+}
+
+##----------------------------------------##
+## Modified by Martinski W. [2025-Sep-06] ##
+##----------------------------------------##
 ScriptHeader()
 {
 	clear
-	printf "\n"
-	printf "${BOLD}##########################################################${CLEARct}\\n"
-	printf "${BOLD}##                                                      ##${CLEARct}\\n"
-	printf "${BOLD}##  __     __          _____   _    _   _____  _____    ##${CLEARct}\\n"
-	printf "${BOLD}##  \ \   / /         |  __ \ | |  | | / ____||  __ \   ##${CLEARct}\\n"
-	printf "${BOLD}##   \ \_/ /__ _  ____| |  | || |__| || |     | |__) |  ##${CLEARct}\\n"
-	printf "${BOLD}##    \   // _  ||_  /| |  | ||  __  || |     |  ___/   ##${CLEARct}\\n"
-	printf "${BOLD}##     | || (_| | / / | |__| || |  | || |____ | |       ##${CLEARct}\\n"
-	printf "${BOLD}##     |_| \__,_|/___||_____/ |_|  |_| \_____||_|       ##${CLEARct}\\n"
-	printf "${BOLD}##                                                      ##${CLEARct}\\n"
-	printf "${BOLD}##              %9s on %-18s         ##${CLEARct}\n" "$SCRIPT_VERSION" "$ROUTER_MODEL"
-	printf "${BOLD}##                                                      ##${CLEARct}\\n"
-	printf "${BOLD}##         https://github.com/AMTM-OSR/YazDHCP          ##${CLEARct}\\n"
-	printf "${BOLD}##    Forked from https://github.com/jackyaz/YazDHCP    ##${CLEARct}\\n"
-	printf "${BOLD}##                                                      ##${CLEARct}\\n"
-	printf "${BOLD}##########################################################${CLEARct}\\n"
-	printf "\n"
+	local spaceLen=52  colorCT
+	[ "$SCRIPT_BRANCH" = "master" ] && colorCT="$GRNct" || colorCT="$MGNTct"
+	echo
+	printf "${BOLD}##########################################################${CLEARct}\n"
+	printf "${BOLD}##                                                      ##${CLEARct}\n"
+	printf "${BOLD}##  __     __          _____   _    _   _____  _____    ##${CLEARct}\n"
+	printf "${BOLD}##  \ \   / /         |  __ \ | |  | | / ____||  __ \   ##${CLEARct}\n"
+	printf "${BOLD}##   \ \_/ /__ _  ____| |  | || |__| || |     | |__) |  ##${CLEARct}\n"
+	printf "${BOLD}##    \   // _  ||_  /| |  | ||  __  || |     |  ___/   ##${CLEARct}\n"
+	printf "${BOLD}##     | || (_| | / / | |__| || |  | || |____ | |       ##${CLEARct}\n"
+	printf "${BOLD}##     |_| \__,_|/___||_____/ |_|  |_| \_____||_|       ##${CLEARct}\n"
+	printf "${BOLD}##                                                      ##${CLEARct}\n"
+	printf "${BOLD}## ${GRNct}%s${CLRct}${BOLD} ##${CLRct}\n" "$(_CenterTextStr_ "$versionMod_TAG" "$spaceLen")"
+	printf "${BOLD}## ${colorCT}%s${CLRct}${BOLD} ##${CLRct}\n" "$(_CenterTextStr_ "$branchxStr_TAG" "$spaceLen")"
+	printf "${BOLD}##                                                      ##${CLEARct}\n"
+	printf "${BOLD}##         https://github.com/AMTM-OSR/YazDHCP          ##${CLEARct}\n"
+	printf "${BOLD}##    Forked from https://github.com/jackyaz/YazDHCP    ##${CLEARct}\n"
+	printf "${BOLD}##                                                      ##${CLEARct}\n"
+	printf "${BOLD}##########################################################${CLEARct}\n\n"
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+_Check_ActiveGuestNetwork_SubnetInfo_()
+{
+   local gnListOfIFaces=""  gnIFaceName  gnInfoStr1  gnInfoStr2
+   local gnSubnetCIDR  gnSubnetMask  gnStartIPadd  gnIFaceCount
+
+   _Update_GuestNetCheck_Status_ InProgress
+
+   _Get_ActiveGuestNetwork_VirtualInterfaces_
+   if [ -z "$gnListOfIFaces" ]
+   then
+       _Init_ActiveGuestNetwork_SubnetInfo_
+       _AllowGuestNetwork_IP_Reservations_ reset false
+       _Update_GuestNetCheck_Status_ DONE
+       return 1
+   fi
+
+   {
+      echo 'var foundActiveGuestNetworks = true;'
+      echo 'var allowGuestNet_IP_Reservation = true;'
+      printf 'var guestNetwork_SubnetInfoArray ='
+   } > "$guestNetInfoJSfilePath"
+
+   _Reset_GuestNetwork_SubnetInfo_
+
+   gnIFaceCount=0
+   gnListOfIFaces="$(echo "$gnListOfIFaces" | sort -i)"
+
+   for gnIFaceName in $gnListOfIFaces
+   do
+       gnInfoStr1="$(ifconfig "$gnIFaceName" | grep -E -A1 "^$guestNetIFaces1RegExp")"
+       gnInfoStr2="$(ip route show | grep -E "dev[[:blank:]]* ${gnIFaceName}[[:blank:]]* proto kernel")"
+       if [ "${#gnInfoStr1}" -eq 0 ] || [ "${#gnInfoStr2}" -eq 0 ]
+       then
+           Print_Output true "Guest Network Interface [$gnIFaceName] was NOT found." "$ERR"
+           continue
+       fi
+       gnSubnetCIDR="$(echo "$gnInfoStr2" | awk -F' ' '{print $1}')"
+       gnSubnetMask="$(echo "$gnInfoStr1" | grep -oE " Mask:${IPv4addrs_RegEx}" | awk -F':' '{print $2}')"
+       gnStartIPadd="$(echo "$gnInfoStr1" | grep -oE " inet addr:${IPv4privtx_RegEx}" | awk -F':' '{print $2}')"
+
+       if [ -z "$gnSubnetCIDR" ] || [ -z "$gnSubnetMask" ] || [ -z "$gnStartIPadd" ]
+       then
+           Print_Output true "Guest Network Interface [$gnIFaceName] info NOT found." "$ERR"
+           continue
+       fi
+       if ! _Add_GuestNetwork_SubnetInfo_
+       then continue
+       fi
+       if [ "$gnIFaceCount" -gt 0 ]
+       then printf ',\n'   >> "$guestNetInfoJSfilePath"
+       else printf '\n[\n' >> "$guestNetInfoJSfilePath"
+       fi
+       {
+           printf "   { GN_IFACE: '${gnIFaceName}',\n"
+           printf "     START_IP: '${gnStartIPadd}',\n"
+           printf "     NET_MASK: '${gnSubnetMask}',\n"
+           printf "     NET_CIDR: '${gnSubnetCIDR}'\n"
+           printf '   }'
+       } >> "$guestNetInfoJSfilePath"
+       gnIFaceCount="$((gnIFaceCount + 1))"
+   done
+
+   if [ "$gnIFaceCount" -eq 0 ]
+   then
+       printf ' [];\n' >> "$guestNetInfoJSfilePath"
+       _Set_FoundActiveGuestNetworks_ false
+       _AllowGuestNetwork_IP_Reservations_ reset false
+   else
+       printf '\n];\n' >> "$guestNetInfoJSfilePath"
+       if ! "$(_Is_DHCP_Static_IPs_Enabled_)" || \
+          ! "$(_AllowGuestNetwork_IP_Reservations_ check)"
+       then
+           _AllowGuestNetwork_IP_Reservations_ disable false
+       fi
+   fi
+   _Update_GuestNetCheck_Status_ DONE
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2024-Jun-27] ##
+## Modified by Martinski W. [2025-Aug-23] ##
 ##----------------------------------------##
 MainMenu()
 {
-	printf "1.    Process ${GRNct}${SCRIPT_CONF}${CLRct}\n\n"
+	local showexport  menuOption  srMenuOptStr  gnMenuOptStr  dhcpStaticIPsOK
+	local allowGuestNetIPaddrReservations  gnAllowReservationsMenuSetting
 
+	_HandleInvalidOption_()
+	{
+		[ -n "$menuOption" ] && \
+		printf "\n${REDct}INVALID input [$menuOption]${CLRct}"
+		printf "\nPlease choose a valid option.\n\n"
+		PressEnter
+	}
+
+	printf "  ${GRNct}1${CLRct}.  Process ${GRNct}${SCRIPT_CONF}${CLRct}\n\n"
+
+	srMenuOptStr="Save/Restore custom user icons"
 	if CheckForCustomIconFiles || CheckForSavedIconFiles
 	then
-		printf "2.    Save/Restore custom user icons found in the ${GRNct}${userIconsDIRpath}${CLRct} directory.\n\n"
+		printf "  ${GRNct}2${CLRct}.  ${srMenuOptStr} found in the ${GRNct}${userIconsDIRpath}${CLRct} directory\n\n"
+	else
+		printf "  ${GRAYEDct}2${CLRct}.  ${GRAYct}${srMenuOptStr}${CLRct}\n"
+		printf "      ${GRAYct}[Currently: ${GRAYEDct} UNAVAILABLE ${CLRct}${GRAYct}]${CLRct}\n\n"
 	fi
 
-	showexport="true"
-	if [ "$(nvram get dhcp_staticlist | wc -m)" -le 1 ]; then
-		showexport="false"
+	dhcpStaticIPsOK="$(_Is_DHCP_Static_IPs_Enabled_)"
+	allowGuestNetIPaddrReservations="$(_AllowGuestNetwork_IP_Reservations_ check)"
+	if "$dhcpStaticIPsOK" && "$allowGuestNetIPaddrReservations"
+	then gnAllowReservationsMenuSetting="${GRNct}ENABLED${CLRct}"
+	else gnAllowReservationsMenuSetting="${MGNTct}DISABLED${CLRct}"
 	fi
-	if [ "$(Firmware_Version_Number "$fwInstalledBranchVer")" -lt "$(Firmware_Version_Number "3004.386.4")" ]
+
+	gnMenuOptStr="Allow Guest Network Client DHCP IP Address Reservations"
+	if "$dhcpStaticIPsOK" && _Get_ActiveGuestNetwork_VirtualInterfaces_
 	then
-		if [ -f /jffs/nvram/dhcp_hostnames ]; then
-			if [ "$(wc -m < /jffs/nvram/dhcp_hostnames)" -le 1 ]; then
-				showexport="false"
-			fi
-		elif [ "$(nvram get dhcp_hostnames | wc -m)" -le 1 ]; then
-			showexport="false"
-		fi
+		printf " ${GRNct}gn${CLRct}.  ${gnMenuOptStr}\n"
+		printf "      [Currently: $gnAllowReservationsMenuSetting]\n\n"
+	else
+		printf " ${GRAYEDct}gn${CLRct}.  ${GRAYct}${gnMenuOptStr}${CLRct}\n"
+		printf "      ${GRAYct}[Currently: ${GRAYEDct} UNAVAILABLE ${CLRct}${GRAYct}]${CLRct}\n\n"
 	fi
-	if [ "$showexport" = "true" ]; then
-		printf "x.    Export DHCP assignments from NVRAM to %s\n\n" "$SCRIPT_NAME"
-	fi
-	printf "u.    Check for updates\\n"
-	printf "uf.   Update %s with latest version (force update)\n\n" "$SCRIPT_NAME"
-	printf "e.    Exit %s\\n\\n" "$SCRIPT_NAME"
-	printf "z.    Uninstall %s\\n" "$SCRIPT_NAME"
-	printf "\n"
-	printf "${BOLD}##########################################################${CLEARct}\\n"
-	printf "\n"
 
-	while true; do
-		printf "Choose an option:    "
-		read -r menu
-		case "$menu" in
+	if _CheckFor_NVRAM_DHCP_Assignments_3004_ || \
+	   _CheckFor_NVRAM_DHCP_Assignments_3006_
+	then showexport=true
+	else showexport=false
+	fi
+	if "$showexport"
+	then
+		printf "  ${GRNct}x${CLRct}.  Export DHCP IP address assignments from NVRAM to %s\n\n" "$SCRIPT_NAME"
+	fi
+	printf "  ${GRNct}u${CLRct}.  Check for updates\n"
+	printf " ${GRNct}uf${CLRct}.  Update %s with latest version (force update)\n\n" "$SCRIPT_NAME"
+	printf "  ${GRNct}e${CLRct}.  Exit %s\n\n" "$SCRIPT_NAME"
+	printf "  ${GRNct}z${CLRct}.  Uninstall %s\n\n" "$SCRIPT_NAME"
+	printf "${BOLD}##########################################################${CLEARct}\n\n"
+
+	while true
+	do
+		printf "Choose an option:  "
+		read -r menuOption
+		case "$menuOption" in
 			1)
-				printf "\\n"
+				printf "\n"
 				if Check_Lock menu; then
 					Menu_ProcessDHCPClients
 				fi
@@ -2445,26 +4239,30 @@ MainMenu()
 					else
 						PressEnter
 					fi
-					break
 				else
-					printf "\nPlease choose a valid option\n\n"
+					_HandleInvalidOption_
 				fi
+				break
 			;;
 			x)
 				if "$showexport"
 				then
-					printf "\\n"
-					if Check_Lock menu; then
-						Export_FW_DHCP_JFFS
+					printf "\n"
+					if Check_Lock menu
+					then
+						if ! Export_FW_DHCP_NVRAM_JFFS
+						then
+							_Check_ActiveGuestNetwork_SubnetInfo_
+						fi
 					fi
 					PressEnter
-					break
 				else
-					printf "\nPlease choose a valid option\n\n"
+					_HandleInvalidOption_
 				fi
+				break
 			;;
 			u)
-				printf "\\n"
+				printf "\n"
 				if Check_Lock menu; then
 					Menu_Update
 				fi
@@ -2472,21 +4270,40 @@ MainMenu()
 				break
 			;;
 			uf)
-				printf "\\n"
+				printf "\n"
 				if Check_Lock menu; then
 					Menu_ForceUpdate
 				fi
 				PressEnter
 				break
 			;;
+			gn)
+				printf "\nPlease wait...\n"
+				if "$dhcpStaticIPsOK" && _Get_ActiveGuestNetwork_VirtualInterfaces_
+				then
+					if ! "$allowGuestNetIPaddrReservations"
+					then _AllowGuestNetwork_IP_Reservations_ enable
+					else _AllowGuestNetwork_IP_Reservations_ disable
+					fi
+					echo
+				elif "$dhcpStaticIPsOK"
+                    then
+					printf "\n${WARN}No available Guest Network with a subnet range separate from the main LAN subnet was found.${CLEARct}\n\n"
+                    else
+                         printf "\n${WARN}The feature to manually assigned DHCP IP address reservations is NOT enabled on the webUI page.${CLEARct}\n\n"
+				fi
+				PressEnter
+				break
+			;;
 			e)
 				ScriptHeader
-				printf "\\n${BOLD}Thanks for using %s!${CLEARct}\\n\\n\\n" "$SCRIPT_NAME"
+				printf "\n${BOLD}Thanks for using %s!${CLEARct}\n\n\n" "$SCRIPT_NAME"
 				exit 0
 			;;
 			z)
-				while true; do
-					printf "\\n${BOLD}Are you sure you want to uninstall %s? (y/n)${CLEARct}\\n" "$SCRIPT_NAME"
+				while true
+				do
+					printf "\n${BOLD}Are you sure you want to uninstall %s? (y/n)${CLEARct}\n" "$SCRIPT_NAME"
 					read -r confirm
 					case "$confirm" in
 						y|Y)
@@ -2501,7 +4318,8 @@ MainMenu()
 				break
 			;;
 			*)
-				printf "\nPlease choose a valid option\n\n"
+				_HandleInvalidOption_
+				break
 			;;
 		esac
 	done
@@ -2511,7 +4329,7 @@ MainMenu()
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2025-Mar-16] ##
+## Modified by Martinski W. [2025-Sep-05] ##
 ##----------------------------------------##
 Menu_Install()
 {
@@ -2543,9 +4361,10 @@ Menu_Install()
 		httpStr="http"
 		portStr=""
 	fi
-	printf "%s will backup NVRAM/JFFS DHCP data as part of the export,\nbut you may wish to screenshot the following WebUI page:" "$SCRIPT_NAME"
-	printf "\n\n${GRNct}%s://%s%s/Advanced_DHCP_Content.asp${CLEARct}\n" "$httpStr" "$(nvram get lan_ipaddr)" "$portStr"
-	printf "\n${BOLD}If you wish to screenshot, please do so now before the WebUI page is updated by %s${CLEARct}.\n" "$SCRIPT_NAME"
+	printf "%s will back up NVRAM/JFFS DHCP IP assignments during installation," "$SCRIPT_NAME"
+     printf "\nbut first you may wish to take screenshots of the following WebUI page:"
+	printf "\n\n${GRNct}%s://%s%s/Advanced_DHCP_Content.asp${CLEARct}\n" "$httpStr" "$mainLAN_IPaddr" "$portStr"
+	printf "\n${BOLD}If you wish to take screenshots, please do so now before the WebUI page\nis updated by %s${CLEARct}.\n" "$SCRIPT_NAME"
 	printf "\n${BOLD}Press the <Enter> key when you are ready to continue...${CLEARct}\n"
 	while true
 	do
@@ -2559,15 +4378,21 @@ Menu_Install()
 	Update_File shared-jy.tar.gz
 	Auto_Startup create 2>/dev/null
 	Auto_ServiceEvent create 2>/dev/null
-	Auto_DNSMASQ create 2>/dev/null
 	Shortcut_Script create
 
 	echo "MAC,IP,HOSTNAME,DNS" > "$SCRIPT_CONF"
+	if ! Export_FW_DHCP_NVRAM_JFFS
+	then
+		_Check_ActiveGuestNetwork_SubnetInfo_
+	fi
+     Auto_DNSMASQ create
 
-	Export_FW_DHCP_JFFS
-
-	Print_Output true "$SCRIPT_NAME installed successfully!" "$PASS"
-
+	if "$webUIupdateOK"
+	then
+		Print_Output true "$SCRIPT_NAME was installed successfully!" "$PASS"
+	else
+		Print_Output true "A problem was found when installing $SCRIPT_NAME!" "$ERR"
+	fi
 	Clear_Lock
 }
 
@@ -2576,90 +4401,141 @@ Menu_Install()
 ##----------------------------------------##
 Menu_ProcessDHCPClients()
 {
-	if ProcessDHCPClients
-	then service restart_dnsmasq >/dev/null 2>&1 ; fi
+	printf "\nPlease wait...\n"
+	if ! Process_DHCP_Clients
+	then
+		Print_Output true "Restarting dnsmasq for new DHCP settings to take effect." "$WARN"
+		service restart_dnsmasq >/dev/null 2>&1
+		echo
+	fi
+	Clear_Lock
+}
+
+##-------------------------------------##
+## Added by Martinski W. [2025-Sep-05] ##
+##-------------------------------------##
+NTP_Ready()
+{
+	local theSleepDelay=15  ntpMaxWaitSecs=600  ntpWaitSecs
+
+	[ "$(nvram get ntp_ready)" -eq 1 ] && return 0
+
+	Check_Lock
+	ntpWaitSecs=0
+	Print_Output true "Waiting for NTP to sync..." "$WARN"
+
+	while [ "$(nvram get ntp_ready)" -eq 0 ] && [ "$ntpWaitSecs" -lt "$ntpMaxWaitSecs" ]
+	do
+		sleep "$theSleepDelay"
+		ntpWaitSecs="$((ntpWaitSecs + theSleepDelay))"
+		if [ "$((ntpWaitSecs % 30))" -eq 0 ]
+		then
+			Print_Output true "Waiting for NTP to sync [$ntpWaitSecs secs]..." "$WARN"
+		fi
+	done
+
+	if [ "$(nvram get ntp_ready)" -eq 1 ]
+	then
+		Print_Output true "NTP has synced [$ntpWaitSecs secs]. $SCRIPT_NAME will now continue." "$PASS"
+	else
+		Print_Output true "NTP failed to sync after 10 minutes. $SCRIPT_NAME will continue anyway." "$WARN"
+	fi
 	Clear_Lock
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2023-Jun-16] ##
+## Modified by Martinski W. [2025-Sep-05] ##
 ##----------------------------------------##
 Menu_Startup()
 {
+	NTP_Ready
+	Check_Lock
+
+	if [ $# -eq 0 ] || [ "$1" != "force" ]
+	then sleep 5
+	fi
 	inStartupMode=true
 	Create_Dirs
-	Set_Version_Custom_Settings "local"
-	Create_Symlinks
+	Set_Version_Custom_Settings local
+	Create_Symlinks 2>/dev/null
 	Auto_Startup create 2>/dev/null
 	Auto_ServiceEvent create 2>/dev/null
+	_Update_GuestNetCheck_Status_ INIT
+	_Check_ActiveGuestNetwork_SubnetInfo_
 	Auto_DNSMASQ create 2>/dev/null
 	Shortcut_Script create
 	Mount_WebUI
 	Clear_Lock
 }
 
-Menu_Update(){
+Menu_Update()
+{
 	Update_Version
 	Clear_Lock
 }
 
-Menu_ForceUpdate(){
+Menu_ForceUpdate()
+{
 	Update_Version force
 	Clear_Lock
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2023-May-28] ##
+## Modified by Martinski W. [2025-Sep-05] ##
+##----------------------------------------##
+_Restore_NVRAM_DHCP_IP_Assignments_()
+{
+	if ! _CheckForSaved_NVRAM_DHCP_Assignments_3004_ && \
+	   ! _CheckForSaved_NVRAM_DHCP_Assignments_3006_
+	then return 0
+	fi
+	local restoredOK=false
+
+	printf "\n${BOLD}Do you want to restore the original NVRAM DHCP assignments from before %s was installed? (y/n):${CLEARct}  " "$SCRIPT_NAME"
+	read -r confirm
+	case "$confirm" in
+		y|Y)
+			_Restore_NVRAM_DHCP_Assignments_3004_
+			_Restore_NVRAM_DHCP_Assignments_3006_
+		;;
+	esac
+
+	if "$doCommitNVRAM"
+	then nvram commit
+	fi
+	if "$doCommitNVRAM" && "$restoredOK"
+	then Print_Output true "The original NVRAM DHCP assignments were restored." "$PASS"
+	else Print_Output true "The original NVRAM DHCP assignments were NOT restored." "$WARN"
+	fi
+}
+
+##----------------------------------------##
+## Modified by Martinski W. [2025-Sep-05] ##
 ##----------------------------------------##
 Menu_Uninstall()
 {
 	Print_Output true "Removing $SCRIPT_NAME..." "$PASS"
 	Auto_Startup delete 2>/dev/null
 	Auto_ServiceEvent delete 2>/dev/null
-	Auto_DNSMASQ delete 2>/dev/null
+	Auto_DNSMASQ delete
 	Shortcut_Script delete
 	umount /www/Advanced_DHCP_Content.asp 2>/dev/null
 	rm -f "$SCRIPT_DIR/Advanced_DHCP_Content.asp"
+	rm -f "$guestNetInfoJSfilePath" "$dhcpGuestNetConfigFPath"
 
-	commitNVRAM=false
-	max7daySecs=604800
-	if [ "$(nvram get $DHCP_LEASE_KEYN)" -gt "$max7daySecs" ]
-	then # Reset NVRAM variable to WebGUI maximum secs #
+	# Maximum LEASE time in secs to store in NVRAM #
+	local max7daySecs=604800
+	local doCommitNVRAM=false
+
+	if [ "$(nvram get "$DHCP_LEASE_KEYN")" -gt "$max7daySecs" ]
+	then
 		nvram set ${DHCP_LEASE_KEYN}="$max7daySecs"
-		commitNVRAM=true
+		doCommitNVRAM=true
 	fi
 
-	printf "\\n${BOLD}Do you want to restore the original NVRAM values from before %s was installed? (y/n):    ${CLEARct}" "$SCRIPT_NAME"
-	read -r confirm
-	case "$confirm" in
-		y|Y)
-			if [ -f "$SCRIPT_DIR/.nvram_jffs_dhcp_staticlist" ]; then
-				nvram set dhcp_staticlist="$(cat "$SCRIPT_DIR/.nvram_jffs_dhcp_staticlist")"
-				commitNVRAM=true
-			fi
+	_Restore_NVRAM_DHCP_IP_Assignments_
 
-			if [ -f "$SCRIPT_DIR/.nvram_jffs_dhcp_hostnames" ]; then
-				nvram set dhcp_hostnames="$(cat "$SCRIPT_DIR/.nvram_jffs_dhcp_hostnames")"
-				commitNVRAM=true
-			fi
-
-			if [ -f "$SCRIPT_DIR/.nvram_dhcp_staticlist" ]; then
-				nvram set dhcp_staticlist="$(cat "$SCRIPT_DIR/.nvram_dhcp_staticlist")"
-				commitNVRAM=true
-			fi
-
-			if [ -f "$SCRIPT_DIR/.nvram_dhcp_hostnames" ]; then
-				nvram set dhcp_hostnames="$(cat "$SCRIPT_DIR/.nvram_dhcp_hostnames")"
-				commitNVRAM=true
-			fi
-		;;
-		*)
-			:
-		;;
-	esac
-	if "$commitNVRAM" ; then nvram commit ; fi
-
-	printf "\\n${BOLD}Do you want to delete %s DHCP clients and NVRAM backup files? (y/n):    ${CLEARct}" "$SCRIPT_NAME"
+	printf "\n${BOLD}Do you want to delete %s DHCP clients and NVRAM backup files? (y/n):${CLEARct}  " "$SCRIPT_NAME"
 	read -r confirm
 	case "$confirm" in
 		y|Y)
@@ -2670,18 +4546,22 @@ Menu_Uninstall()
 		;;
 	esac
 
+	Set_Version_Custom_Settings delete
 	rm -rf "$SCRIPT_WEB_DIR" 2>/dev/null
 	rm -f "/jffs/scripts/$SCRIPT_NAME" 2>/dev/null
 	Clear_Lock
 	Print_Output true "Uninstall completed" "$PASS"
 
-	if "$commitNVRAM"
+	if "$doCommitNVRAM"
 	then
 		Print_Output true "Restarting dnsmasq to restore DHCP settings." "$PASS"
 		service restart_dnsmasq >/dev/null 2>&1
 	fi
 }
 
+##----------------------------------------##
+## Modified by Martinski W. [2025-Sep-05] ##
+##----------------------------------------##
 Check_Requirements()
 {
 	CHECKSFAILED="false"
@@ -2693,17 +4573,17 @@ Check_Requirements()
 		Print_Output true "Custom JFFS Scripts enabled" "$WARN"
 	fi
 
-	if ! Firmware_Version_Check
+	if ! Firmware_Version_Check || \
+	   [ "$(FirmwareVersionNum "$fwInstalledBranchVer")" -lt "$(FirmwareVersionNum "3004.386.4")" ]
 	then
 		Print_Output true "Unsupported firmware version detected" "$ERR"
-		Print_Output true "$SCRIPT_NAME requires Merlin 384.15/384.13_4 or Fork 43E5 (or later)" "$ERR"
+		Print_Output true "$SCRIPT_NAME requires Merlin F/W 3004.386.4 version (or later)" "$ERR"
 		CHECKSFAILED="true"
 	fi
 
-	if [ "$CHECKSFAILED" = "false" ]; then
-		return 0
-	else
-		return 1
+	if [ "$CHECKSFAILED" = "false" ]
+	then return 0
+	else return 1
 	fi
 }
 
@@ -2758,25 +4638,38 @@ EOF
 ## Modified by Martinski W. [2024-Feb-26] ##
 ##----------------------------------------##
 # Catch unexpected exit to release lock #
-trap 'Clear_Lock; exit 10' EXIT HUP INT QUIT ABRT TERM
+trap 'Clear_Lock; exit 10' HUP INT QUIT ABRT TERM
 
-if [ "$SCRIPT_BRANCH" = "master" ]
-then SCRIPT_VERS_INFO="[$branchx_TAG]"
-else SCRIPT_VERS_INFO="[$version_TAG, $branchx_TAG]"
+if [ $# -eq 1 ] && [ "$1" = "resetLock" ]
+then Clear_Lock ; exit 0
 fi
 
+if [ "$SCRIPT_BRANCH" = "master" ]
+then SCRIPT_VERS_INFO=""
+else SCRIPT_VERS_INFO="[$versionDev_TAG]"
+fi
+
+##----------------------------------------##
+## Modified by Martinski W. [2025-Sep-05] ##
+##----------------------------------------##
 if [ $# -eq 0 ] || [ -z "$1" ]
 then
 	Create_Dirs
 	Set_Version_Custom_Settings local
-	Create_Symlinks
+	Create_Symlinks 2>/dev/null
 	Auto_Startup create 2>/dev/null
 	Auto_ServiceEvent create 2>/dev/null
-	Auto_DNSMASQ create 2>/dev/null
+	_Update_GuestNetCheck_Status_ INIT
+	_Check_ActiveGuestNetwork_SubnetInfo_
+	Auto_DNSMASQ create
 	Shortcut_Script create
-	_CheckFor_WebGUI_Page_
-	ScriptHeader
-	MainMenu
+	if _CheckFor_WebGUI_Page_
+	then
+		ScriptHeader
+		MainMenu
+	else
+		printf "${REDct}Exiting...${CLRct}\n\n"
+	fi
 	exit 0
 fi
 
@@ -2786,41 +4679,67 @@ case "$1" in
 		Menu_Install
 		exit 0
 	;;
-	startup)
+	uninstall)
 		Check_Lock
-		if [ $# -gt 1 ] && [ "$2" != "force" ]; then
-			sleep 5
-		fi
-		Menu_Startup
+		Menu_Uninstall
+		exit 0
+	;;
+	startup)
+		shift
+		Menu_Startup "$@"
 		exit 0
 	;;
 	##----------------------------------------##
-	## Modified by Martinski W. [2023-Apr-16] ##
+	## Modified by Martinski W. [2025-Sep-05] ##
 	##----------------------------------------##
 	service_event)
-		if [ "$2" = "start" ]
+		if [ "$2" = "restart" ] && [ "$3" = "wireless" ]
+		then
+			NTP_Ready
+			Print_Output true "Wireless restarted. Checking for available Guest Networks in 20 secs...." "$PASS"
+			Check_Lock
+			sleep 20
+			_Update_GuestNetCheck_Status_ INIT
+			_Check_ActiveGuestNetwork_SubnetInfo_
+			Process_DHCP_Clients
+			Clear_Lock
+		elif [ "$2" = "start" ]
 		then
 			case "$3" in
 				"$SCRIPT_NAME")
-						Conf_FromSettings
+					Conf_FromSettings
+				;;
+				"${SCRIPT_NAME}backupconfig")
+					BackUpConfigSettings
 				;;
 				"${SCRIPT_NAME}checkupdate")
-						Update_Check
+					Update_Check
 				;;
 				"${SCRIPT_NAME}doupdate")
-						Update_Version force unattended
+					Update_Version force unattended
 				;;
 				"${SCRIPT_NAME}checkIcons")
-						CheckUserIconFiles
+					CheckUserIconFiles
 				;;
 				"${SCRIPT_NAME}backupIcons")
-						BackUpUserIconFiles
+					BackUpUserIconFiles
 				;;
 				"${SCRIPT_NAME}restoreIcons_reqList")
-						GetSavedBackupFilesList
+					GetSavedBackupFilesList
 				;;
 				"${SCRIPT_NAME}restoreIcons_reqNum_"*)
-						RestoreUserIconFilesReq "$3"
+					RestoreUserIconFilesReq "$3"
+				;;
+				"${SCRIPT_NAME}checkGuestNetReservations")
+					_Update_GuestNetCheck_Status_ INIT
+					_Check_ActiveGuestNetwork_SubnetInfo_
+					Process_DHCP_Clients
+				;;
+				"${SCRIPT_NAME}enableGuestNetReservations")
+					_AllowGuestNetwork_IP_Reservations_ enable
+				;;
+				"${SCRIPT_NAME}disableGuestNetReservations")
+					_AllowGuestNetwork_IP_Reservations_ disable
 				;;
 			esac
 		fi
@@ -2849,18 +4768,14 @@ case "$1" in
 	setversion)
 		Set_Version_Custom_Settings local
 		Set_Version_Custom_Settings server "$SCRIPT_VERSION"
-		if [ -z "$2" ]; then
+		if [ $# -lt 2 ] || [ -z "$2" ]
+          then
 			exec "$0"
 		fi
 		exit 0
 	;;
 	checkupdate)
 		Update_Check
-		exit 0
-	;;
-	uninstall)
-		Check_Lock
-		Menu_Uninstall
 		exit 0
 	;;
 	develop)


### PR DESCRIPTION
Added a new feature to allow assigning DHCP IP address reservations to clients on available Guest Networks whose subnet (e.g. 192.168.123.0/24) is separate from the main LAN subnet (e.g. 192.168.50.0/24).

![YazDHCP_v1 2 0_WebUI_AllowGN_IPs_ENABLED1](https://github.com/user-attachments/assets/e2a4f06a-f70a-4a25-b701-088d2d0438d0)

