### PR TITLE
Workaround for Entware Binaries using RUNPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # YazDHCP
 
-## v1.2.5
+## v1.2.6
 
-### Updated on 2026-Mar-21
+### Updated on 2026-Apr-11
 
 ## About
 

--- a/YazDHCP.sh
+++ b/YazDHCP.sh
@@ -13,7 +13,7 @@
 ##    Forked from https://github.com/jackyaz/YazDHCP    ##
 ##                                                      ##
 ##########################################################
-# Last Modified: 2026-Mar-21
+# Last Modified: 2026-Apr-11
 #---------------------------------------------------------
 
 #############################################
@@ -29,8 +29,8 @@
 
 ### Start of script variables ###
 readonly SCRIPT_NAME="YazDHCP"
-readonly SCRIPT_VERSION="v1.2.5"
-readonly SCRIPT_VERSTAG="26032100"
+readonly SCRIPT_VERSION="v1.2.6"
+readonly SCRIPT_VERSTAG="26041104"
 SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/AMTM-OSR/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME.d"
@@ -76,6 +76,9 @@ readonly versionMod_TAG="$SCRIPT_VERSION on $ROUTER_MODEL"
 
 # To support automatic script updates from AMTM #
 doScriptUpdateFromAMTM=true
+
+# Workaround for Entware ELF binaries compiled with RUNPATH #
+unset LD_LIBRARY_PATH
 
 # Give higher priority to built-in binaries #
 export PATH="/bin:/usr/bin:/sbin:/usr/sbin:$PATH"


### PR DESCRIPTION
Added "`unset LD_LIBRARY_PATH`" line as a workaround due to the latest Entware binaries using the **RUNPATH** embedded library search path mechanism instead of the previous **RPATH** method. RUNPATH is searched **AFTER** the LD_LIBRARY_PATH definitions, whereas **RPATH** has higher priority than the LD_LIBRARY_PATH environment variable, so it's searched **FIRST**.
