### PR TITLE
Fix for Missing "cookie" Helper Functions

### DIFF
--- a/Advanced_DHCP_Content.asp
+++ b/Advanced_DHCP_Content.asp
@@ -55,9 +55,9 @@ thead.collapsible-jquery {
 <script language="JavaScript" type="text/javascript" src="/base64.js"></script>
 <script>
 
-/**----------------------------------------**/
-/** Modified by Martinski W. [2025-Nov-01] **/
-/**----------------------------------------**/
+/**----------------------------**/
+/** Last Modified: 2026-Jul-25 **/
+/**----------------------------**/
 
 const actionScriptPrefix = "start_YazDHCP";
 
@@ -1489,29 +1489,70 @@ function GetVersionNumber(versiontype)
 	}
 }
 
-function GetCookie(cookiename,returntype){
+/**----------------------------------------------------------------**
+ ** Compatibility layer for the latest AsusWRT6 routers, such as
+ ** the GT-BE19000AI, where the previous global 'cookie' helper 
+ ** functions defined in the 'state.js' file are now removed in 
+ ** favour of using the "window.localStorage" property.
+ **----------------------------------------------------------------**/
+if (typeof window.cookie === "undefined" ||
+    typeof window.cookie.get !== "function" ||
+    typeof window.cookie.set !== "function")
+{
+    window.cookie = {
+        get: function (key) {
+            return window.localStorage.getItem(key);
+        },
+
+        /** In the previous 'cookie' function a 3rd argument was given for 'days' **/
+        /** Here, we ignore the value because there is no expiration date anymore **/
+        set: function (key, value, days) {
+            window.localStorage.setItem(key, String(value));
+        },
+
+        unset: function (key) {
+            window.localStorage.removeItem(key);
+        }
+    };
+
+    console.log("Installed localStorage compatibility for cookie API.");
+}
+
+function GetCookie(cookiename, returntype)
+{
 	var s;
-	if ((s = cookie.get("yazdhcp_"+cookiename)) != null){
-		return cookie.get("yazdhcp_"+cookiename);
-	}
-	else{
-		if(returntype == "string"){
-			return "";
+	if ((s = cookie.get('yazdhcp_' + cookiename)) !== null)
+	{
+		if (returntype === 'string')
+		{
+			return cookie.get('yazdhcp_' + cookiename);
 		}
-		else if(returntype == "number"){
+		else if (returntype === 'number')
+		{
+			return cookie.get('yazdhcp_' + cookiename) * 1;
+		}
+	}
+	else
+	{
+		if (returntype === 'string')
+		{
+			return '';
+		}
+		else if (returntype === 'number')
+		{
 			return 0;
 		}
 	}
 }
 
-function SetCookie(cookiename,cookievalue){
-	cookie.set("yazdhcp_"+cookiename, cookievalue, 31);
-}
+function SetCookie(cookiename, cookievalue)
+{ cookie.set('yazdhcp_' + cookiename, cookievalue, 31); }
 
-function AddEventHandlers(){
+function AddEventHandlers()
+{
 	$(".collapsible-jquery").click(function(){
 		$(this).siblings().toggle("fast",function(){
-			if($(this).css("display") == "none"){
+			if ($(this).css("display") == "none"){
 				SetCookie($(this).siblings()[0].id,"collapsed");
 			}
 			else{
@@ -1521,7 +1562,7 @@ function AddEventHandlers(){
 	});
 
 	$(".collapsible-jquery").each(function(index,element){
-		if(GetCookie($(this)[0].id,"string") == "collapsed"){
+		if (GetCookie($(this)[0].id,"string") == "collapsed"){
 			$(this).siblings().toggle(false);
 		}
 		else{

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## v1.2.7
 
-### Updated on 2026-Jul-24
+### Updated on 2026-Jul-25
 
 ## About
 

--- a/YazDHCP.sh
+++ b/YazDHCP.sh
@@ -13,7 +13,7 @@
 ##    Forked from https://github.com/jackyaz/YazDHCP    ##
 ##                                                      ##
 ##########################################################
-# Last Modified: 2026-Jul-24
+# Last Modified: 2026-Jul-25
 #---------------------------------------------------------
 
 #############################################
@@ -30,7 +30,7 @@
 ### Start of script variables ###
 readonly SCRIPT_NAME="YazDHCP"
 readonly SCRIPT_VERSION="v1.2.7"
-readonly SCRIPT_VERSTAG="26072421"
+readonly SCRIPT_VERSTAG="26072500"
 SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/AMTM-OSR/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME.d"


### PR DESCRIPTION
Fix for compatibility issue with latest AsusWRT6 routers, such as the GT-BE19000AI, running 3006.102.8 F/W version, where the webpage generates errors due to missing "cookie" helper functions previously defined in the 'state.js' file (Ported from Unbound Stats WebUI ASP fix supplied by @ExtremeFiretop).
